### PR TITLE
feat: Add lookup tables to existing fixedpoint gadgets and add gadgets sin/cos.

### DIFF
--- a/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/boolean.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/boolean.hpp
@@ -32,14 +32,17 @@ namespace nil {
                 static constexpr const char *AND = "and";
                 static constexpr const char *OR = "or";
                 static constexpr const char *XOR = "xor";
+                static constexpr const char *INVERSE = "inverse";
                 static constexpr const char *FULL_AND = "fixedpoint_boolean_table/and";
                 static constexpr const char *FULL_OR = "fixedpoint_boolean_table/or";
                 static constexpr const char *FULL_XOR = "fixedpoint_boolean_table/xor";
+                static constexpr const char *FULL_INVERSE = "fixedpoint_boolean_table/inverse";
 
                 fixedpoint_boolean_table() : lookup_table_definition(TABLE_NAME) {
                     this->subtables[AND] = {{0, 1, 2}, 0, 3};
                     this->subtables[OR] = {{0, 1, 3}, 0, 3};
                     this->subtables[XOR] = {{0, 1, 4}, 0, 3};
+                    this->subtables[INVERSE] = {{1, 5}, 0, 1};
                 }
 
                 virtual void generate() {
@@ -48,11 +51,12 @@ namespace nil {
                     std::vector<value_type> and_ = {0, 0, 0, 1};
                     std::vector<value_type> or_ = {0, 1, 1, 1};
                     std::vector<value_type> xor_ = {0, 1, 1, 0};
-                    this->_table = {x, y, and_, or_, xor_};
+                    std::vector<value_type> inv_ = {1, 0};
+                    this->_table = {x, y, and_, or_, xor_, inv_};
                 }
 
                 virtual std::size_t get_columns_number() {
-                    return 5;
+                    return 6;
                 }
 
                 virtual std::size_t get_rows_number() {

--- a/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/boolean.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/boolean.hpp
@@ -1,0 +1,66 @@
+#ifndef CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_BOOLEAN_TABLE_HPP
+#define CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_BOOLEAN_TABLE_HPP
+
+#include <string>
+#include <map>
+
+#include <nil/crypto3/zk/snark/arithmetization/plonk/detail/lookup_table_definition.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/tables.hpp>
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+
+            ////////////////////////////////////////////////////////////////////
+            //////// BOOLEAN
+            ////////////////////////////////////////////////////////////////////
+
+            // This lookup table exists for fun, demo, and experimental reasons (because it is small).
+            // (and doesn't actually use fixed point representation, just the values 0 and 1 of the underlying field)
+
+            template<typename BlueprintFieldType>
+            class fixedpoint_boolean_table
+                : public nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType> {
+
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using fixedpoint_tables = FixedPointTables<BlueprintFieldType>;
+                using value_type = typename BlueprintFieldType::value_type;
+
+            public:
+                static constexpr const char *TABLE_NAME = "fixedpoint_boolean_table";
+                static constexpr const char *AND = "and";
+                static constexpr const char *OR = "or";
+                static constexpr const char *XOR = "xor";
+                static constexpr const char *FULL_AND = "fixedpoint_boolean_table/and";
+                static constexpr const char *FULL_OR = "fixedpoint_boolean_table/or";
+                static constexpr const char *FULL_XOR = "fixedpoint_boolean_table/xor";
+
+                fixedpoint_boolean_table() : lookup_table_definition(TABLE_NAME) {
+                    this->subtables[AND] = {{0, 1, 2}, 0, 3};
+                    this->subtables[OR] = {{0, 1, 3}, 0, 3};
+                    this->subtables[XOR] = {{0, 1, 4}, 0, 3};
+                }
+
+                virtual void generate() {
+                    std::vector<value_type> x = {0, 0, 1, 1};
+                    std::vector<value_type> y = {0, 1, 0, 1};
+                    std::vector<value_type> and_ = {0, 0, 0, 1};
+                    std::vector<value_type> or_ = {0, 1, 1, 1};
+                    std::vector<value_type> xor_ = {0, 1, 1, 0};
+                    this->_table = {x, y, and_, or_, xor_};
+                }
+
+                virtual std::size_t get_columns_number() {
+                    return 5;
+                }
+
+                virtual std::size_t get_rows_number() {
+                    return 4;
+                }
+            };
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_BOOLEAN_TABLE_HPP

--- a/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/exp.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/exp.hpp
@@ -40,9 +40,9 @@ namespace nil {
                 virtual void generate() {
                     BLUEPRINT_RELEASE_ASSERT(fixedpoint_tables::RangeLen == fixedpoint_tables::ExpBLen);
                     auto input = fixedpoint_tables::get_range_table();
-                    auto output_b = fixedpoint_tables::get_exp_b_16();
                     auto output_a = fixedpoint_tables::get_exp_a_16();
-                    this->_table = {input, output_b, output_a};
+                    auto output_b = fixedpoint_tables::get_exp_b_16();
+                    this->_table = {input, output_a, output_b};
                 }
 
                 virtual std::size_t get_columns_number() {
@@ -83,9 +83,9 @@ namespace nil {
                 virtual void generate() {
                     BLUEPRINT_RELEASE_ASSERT(fixedpoint_tables::RangeLen == fixedpoint_tables::ExpBLen);
                     auto input = fixedpoint_tables::get_range_table();
-                    auto output_b = fixedpoint_tables::get_exp_b_32();
                     auto output_a = fixedpoint_tables::get_exp_a_32();
-                    this->_table = {input, output_b, output_a};
+                    auto output_b = fixedpoint_tables::get_exp_b_32();
+                    this->_table = {input, output_a, output_b};
                 }
 
                 virtual std::size_t get_columns_number() {

--- a/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/exp.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/exp.hpp
@@ -12,11 +12,11 @@ namespace nil {
         namespace components {
 
             ////////////////////////////////////////////////////////////////////
-            //////// EXP A 16
+            //////// EXP 16
             ////////////////////////////////////////////////////////////////////
 
             template<typename BlueprintFieldType>
-            class fixedpoint_exp_a16_table
+            class fixedpoint_exp_16_table
                 : public nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType> {
 
                 using lookup_table_definition =
@@ -24,98 +24,29 @@ namespace nil {
                 using fixedpoint_tables = FixedPointTables<BlueprintFieldType>;
 
             public:
-                static constexpr const char *TABLE_NAME = "fixedpoint_exp_a16_table";
-                static constexpr const char *SUBTABLE_NAME = "full";
-                static constexpr const char *FULL_TABLE_NAME = "fixedpoint_exp_a16_table/full";
+                static constexpr const char *TABLE_NAME = "fixedpoint_exp_16_table";
 
-                // TACEO_TODO this hardcoded 0/1 is probably wrong
-                fixedpoint_exp_a16_table() : lookup_table_definition(TABLE_NAME) {
-                    this->subtables[SUBTABLE_NAME] = {{0, 1}, 0, fixedpoint_tables::ExpALen - 1};
-                }
+                static constexpr const char *A_SUBTABLE_NAME = "a";
+                static constexpr const char *A_TABLE_NAME = "fixedpoint_exp_16_table/a";
 
-                virtual void generate() {
-                    auto input = fixedpoint_tables::get_exp_a_input();
-                    auto output = fixedpoint_tables::get_exp_a_16();
-                    this->_table = {input, output};
-                }
+                static constexpr const char *B_SUBTABLE_NAME = "b";
+                static constexpr const char *B_TABLE_NAME = "fixedpoint_exp_16_table/b";
 
-                virtual std::size_t get_columns_number() {
-                    return 2;
-                }
-
-                virtual std::size_t get_rows_number() {
-                    return fixedpoint_tables::ExpALen;
-                }
-            };
-
-            ////////////////////////////////////////////////////////////////////
-            //////// EXP A 32
-            ////////////////////////////////////////////////////////////////////
-
-            template<typename BlueprintFieldType>
-            class fixedpoint_exp_a32_table
-                : public nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType> {
-
-                using lookup_table_definition =
-                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
-                using fixedpoint_tables = FixedPointTables<BlueprintFieldType>;
-
-            public:
-                static constexpr const char *TABLE_NAME = "fixedpoint_exp_a32_table";
-                static constexpr const char *SUBTABLE_NAME = "full";
-                static constexpr const char *FULL_TABLE_NAME = "fixedpoint_exp_a32_table/full";
-
-                // TACEO_TODO this hardcoded 0/1 is probably wrong
-                fixedpoint_exp_a32_table() : lookup_table_definition(TABLE_NAME) {
-                    this->subtables[SUBTABLE_NAME] = {{0, 1}, 0, fixedpoint_tables::ExpALen - 1};
-                }
-
-                virtual void generate() {
-                    auto input = fixedpoint_tables::get_exp_a_input();
-                    auto output = fixedpoint_tables::get_exp_a_32();
-                    this->_table = {input, output};
-                }
-
-                virtual std::size_t get_columns_number() {
-                    return 2;
-                }
-
-                virtual std::size_t get_rows_number() {
-                    return fixedpoint_tables::ExpALen;
-                }
-            };
-
-            ////////////////////////////////////////////////////////////////////
-            //////// EXP B 16
-            ////////////////////////////////////////////////////////////////////
-
-            template<typename BlueprintFieldType>
-            class fixedpoint_exp_b16_table
-                : public nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType> {
-
-                using lookup_table_definition =
-                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
-                using fixedpoint_tables = FixedPointTables<BlueprintFieldType>;
-
-            public:
-                static constexpr const char *TABLE_NAME = "fixedpoint_exp_b16_table";
-                static constexpr const char *SUBTABLE_NAME = "full";
-                static constexpr const char *FULL_TABLE_NAME = "fixedpoint_exp_b16_table/full";
-
-                // TACEO_TODO this hardcoded 0/1 is probably wrong
-                fixedpoint_exp_b16_table() : lookup_table_definition(TABLE_NAME) {
-                    this->subtables[SUBTABLE_NAME] = {{0, 1}, 0, fixedpoint_tables::ExpBLen - 1};
+                fixedpoint_exp_16_table() : lookup_table_definition(TABLE_NAME) {
+                    this->subtables[B_SUBTABLE_NAME] = {{0, 2}, 0, fixedpoint_tables::ExpBLen - 1};
+                    this->subtables[A_SUBTABLE_NAME] = {{0, 1}, 0, fixedpoint_tables::ExpALen - 1};
                 }
 
                 virtual void generate() {
                     BLUEPRINT_RELEASE_ASSERT(fixedpoint_tables::RangeLen == fixedpoint_tables::ExpBLen);
                     auto input = fixedpoint_tables::get_range_table();
-                    auto output = fixedpoint_tables::get_exp_b_16();
-                    this->_table = {input, output};
+                    auto output_b = fixedpoint_tables::get_exp_b_16();
+                    auto output_a = fixedpoint_tables::get_exp_a_16();
+                    this->_table = {input, output_b, output_a};
                 }
 
                 virtual std::size_t get_columns_number() {
-                    return 2;
+                    return 3;
                 }
 
                 virtual std::size_t get_rows_number() {
@@ -124,11 +55,11 @@ namespace nil {
             };
 
             ////////////////////////////////////////////////////////////////////
-            //////// EXP B 32
+            //////// EXP 32
             ////////////////////////////////////////////////////////////////////
 
             template<typename BlueprintFieldType>
-            class fixedpoint_exp_b32_table
+            class fixedpoint_exp_32_table
                 : public nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType> {
 
                 using lookup_table_definition =
@@ -136,24 +67,29 @@ namespace nil {
                 using fixedpoint_tables = FixedPointTables<BlueprintFieldType>;
 
             public:
-                static constexpr const char *TABLE_NAME = "fixedpoint_exp_b32_table";
-                static constexpr const char *SUBTABLE_NAME = "full";
-                static constexpr const char *FULL_TABLE_NAME = "fixedpoint_exp_b32_table/full";
+                static constexpr const char *TABLE_NAME = "fixedpoint_exp_32_table";
 
-                // TACEO_TODO this hardcoded 0/1 is probably wrong
-                fixedpoint_exp_b32_table() : lookup_table_definition(TABLE_NAME) {
-                    this->subtables[SUBTABLE_NAME] = {{0, 1}, 0, fixedpoint_tables::ExpBLen - 1};
+                static constexpr const char *A_SUBTABLE_NAME = "a";
+                static constexpr const char *A_TABLE_NAME = "fixedpoint_exp_32_table/a";
+
+                static constexpr const char *B_SUBTABLE_NAME = "b";
+                static constexpr const char *B_TABLE_NAME = "fixedpoint_exp_32_table/b";
+
+                fixedpoint_exp_32_table() : lookup_table_definition(TABLE_NAME) {
+                    this->subtables[B_SUBTABLE_NAME] = {{0, 2}, 0, fixedpoint_tables::ExpBLen - 1};
+                    this->subtables[A_SUBTABLE_NAME] = {{0, 1}, 0, fixedpoint_tables::ExpALen - 1};
                 }
 
                 virtual void generate() {
                     BLUEPRINT_RELEASE_ASSERT(fixedpoint_tables::RangeLen == fixedpoint_tables::ExpBLen);
                     auto input = fixedpoint_tables::get_range_table();
-                    auto output = fixedpoint_tables::get_exp_b_32();
-                    this->_table = {input, output};
+                    auto output_b = fixedpoint_tables::get_exp_b_32();
+                    auto output_a = fixedpoint_tables::get_exp_a_32();
+                    this->_table = {input, output_b, output_a};
                 }
 
                 virtual std::size_t get_columns_number() {
-                    return 2;
+                    return 3;
                 }
 
                 virtual std::size_t get_rows_number() {

--- a/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/exp.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/exp.hpp
@@ -1,0 +1,168 @@
+#ifndef CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_EXP_TABLE_HPP
+#define CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_EXP_TABLE_HPP
+
+#include <string>
+#include <map>
+
+#include <nil/crypto3/zk/snark/arithmetization/plonk/detail/lookup_table_definition.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/tables.hpp>
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+
+            ////////////////////////////////////////////////////////////////////
+            //////// EXP A 16
+            ////////////////////////////////////////////////////////////////////
+
+            template<typename BlueprintFieldType>
+            class fixedpoint_exp_a16_table
+                : public nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType> {
+
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using fixedpoint_tables = FixedPointTables<BlueprintFieldType>;
+
+            public:
+                static constexpr const char *TABLE_NAME = "fixedpoint_exp_a16_table";
+                static constexpr const char *SUBTABLE_NAME = "full";
+                static constexpr const char *FULL_TABLE_NAME = "fixedpoint_exp_a16_table/full";
+
+                // TACEO_TODO this hardcoded 0/1 is probably wrong
+                fixedpoint_exp_a16_table() : lookup_table_definition(TABLE_NAME) {
+                    this->subtables[SUBTABLE_NAME] = {{0, 1}, 0, fixedpoint_tables::ExpALen - 1};
+                }
+
+                virtual void generate() {
+                    auto input = fixedpoint_tables::get_exp_a_input();
+                    auto output = fixedpoint_tables::get_exp_a_16();
+                    this->_table = {input, output};
+                }
+
+                virtual std::size_t get_columns_number() {
+                    return 2;
+                }
+
+                virtual std::size_t get_rows_number() {
+                    return fixedpoint_tables::ExpALen;
+                }
+            };
+
+            ////////////////////////////////////////////////////////////////////
+            //////// EXP A 32
+            ////////////////////////////////////////////////////////////////////
+
+            template<typename BlueprintFieldType>
+            class fixedpoint_exp_a32_table
+                : public nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType> {
+
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using fixedpoint_tables = FixedPointTables<BlueprintFieldType>;
+
+            public:
+                static constexpr const char *TABLE_NAME = "fixedpoint_exp_a32_table";
+                static constexpr const char *SUBTABLE_NAME = "full";
+                static constexpr const char *FULL_TABLE_NAME = "fixedpoint_exp_a32_table/full";
+
+                // TACEO_TODO this hardcoded 0/1 is probably wrong
+                fixedpoint_exp_a32_table() : lookup_table_definition(TABLE_NAME) {
+                    this->subtables[SUBTABLE_NAME] = {{0, 1}, 0, fixedpoint_tables::ExpALen - 1};
+                }
+
+                virtual void generate() {
+                    auto input = fixedpoint_tables::get_exp_a_input();
+                    auto output = fixedpoint_tables::get_exp_a_32();
+                    this->_table = {input, output};
+                }
+
+                virtual std::size_t get_columns_number() {
+                    return 2;
+                }
+
+                virtual std::size_t get_rows_number() {
+                    return fixedpoint_tables::ExpALen;
+                }
+            };
+
+            ////////////////////////////////////////////////////////////////////
+            //////// EXP B 16
+            ////////////////////////////////////////////////////////////////////
+
+            template<typename BlueprintFieldType>
+            class fixedpoint_exp_b16_table
+                : public nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType> {
+
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using fixedpoint_tables = FixedPointTables<BlueprintFieldType>;
+
+            public:
+                static constexpr const char *TABLE_NAME = "fixedpoint_exp_b16_table";
+                static constexpr const char *SUBTABLE_NAME = "full";
+                static constexpr const char *FULL_TABLE_NAME = "fixedpoint_exp_b16_table/full";
+
+                // TACEO_TODO this hardcoded 0/1 is probably wrong
+                fixedpoint_exp_b16_table() : lookup_table_definition(TABLE_NAME) {
+                    this->subtables[SUBTABLE_NAME] = {{0, 1}, 0, fixedpoint_tables::ExpBLen - 1};
+                }
+
+                virtual void generate() {
+                    BLUEPRINT_RELEASE_ASSERT(fixedpoint_tables::RangeLen == fixedpoint_tables::ExpBLen);
+                    auto input = fixedpoint_tables::get_range_table();
+                    auto output = fixedpoint_tables::get_exp_b_16();
+                    this->_table = {input, output};
+                }
+
+                virtual std::size_t get_columns_number() {
+                    return 2;
+                }
+
+                virtual std::size_t get_rows_number() {
+                    return fixedpoint_tables::ExpBLen;
+                }
+            };
+
+            ////////////////////////////////////////////////////////////////////
+            //////// EXP B 32
+            ////////////////////////////////////////////////////////////////////
+
+            template<typename BlueprintFieldType>
+            class fixedpoint_exp_b32_table
+                : public nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType> {
+
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using fixedpoint_tables = FixedPointTables<BlueprintFieldType>;
+
+            public:
+                static constexpr const char *TABLE_NAME = "fixedpoint_exp_b32_table";
+                static constexpr const char *SUBTABLE_NAME = "full";
+                static constexpr const char *FULL_TABLE_NAME = "fixedpoint_exp_b32_table/full";
+
+                // TACEO_TODO this hardcoded 0/1 is probably wrong
+                fixedpoint_exp_b32_table() : lookup_table_definition(TABLE_NAME) {
+                    this->subtables[SUBTABLE_NAME] = {{0, 1}, 0, fixedpoint_tables::ExpBLen - 1};
+                }
+
+                virtual void generate() {
+                    BLUEPRINT_RELEASE_ASSERT(fixedpoint_tables::RangeLen == fixedpoint_tables::ExpBLen);
+                    auto input = fixedpoint_tables::get_range_table();
+                    auto output = fixedpoint_tables::get_exp_b_32();
+                    this->_table = {input, output};
+                }
+
+                virtual std::size_t get_columns_number() {
+                    return 2;
+                }
+
+                virtual std::size_t get_rows_number() {
+                    return fixedpoint_tables::ExpBLen;
+                }
+            };
+
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_EXP_TABLE_HPP

--- a/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp
@@ -1,0 +1,50 @@
+#ifndef CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_RANGE_TABLE_HPP
+#define CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_RANGE_TABLE_HPP
+
+#include <string>
+#include <map>
+
+#include <nil/crypto3/zk/snark/arithmetization/plonk/detail/lookup_table_definition.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/tables.hpp>
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+
+            template<typename BlueprintFieldType>
+            class fixedpoint_range_table
+                : public nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType> {
+
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using fixedpoint_tables = FixedPointTables<BlueprintFieldType>;
+
+            public:
+                static constexpr const char *TABLE_NAME = "fixedpoint_range_table";
+
+                static constexpr const char *SUBTABLE_NAME = "fixedpoint_range_table/full";
+
+                // TACEO_TODO this hardcoded 0 is probably wrong
+                fixedpoint_range_table() : lookup_table_definition(TABLE_NAME) {
+                    this->subtables[SUBTABLE_NAME] = {{0}, 0, fixedpoint_tables::RangeLen - 1};
+                }
+
+                virtual void generate() {
+                    auto table = fixedpoint_tables::get_range_table();
+                    this->_table = {table};
+                }
+
+                virtual std::size_t get_columns_number() {
+                    return 1;
+                }
+
+                virtual std::size_t get_rows_number() {
+                    return fixedpoint_tables::RangeLen;
+                }
+            };
+
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_RANGE_TABLE_HPP

--- a/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp
@@ -21,8 +21,8 @@ namespace nil {
 
             public:
                 static constexpr const char *TABLE_NAME = "fixedpoint_range_table";
-
-                static constexpr const char *SUBTABLE_NAME = "fixedpoint_range_table/full";
+                static constexpr const char *SUBTABLE_NAME = "full";
+                static constexpr const char *FULL_TABLE_NAME = "fixedpoint_range_table/full";
 
                 // TACEO_TODO this hardcoded 0 is probably wrong
                 fixedpoint_range_table() : lookup_table_definition(TABLE_NAME) {

--- a/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/tester.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/tester.hpp
@@ -26,12 +26,18 @@ namespace nil {
 
             // For each gate
             for (auto &gate : gates) {
-                auto tag = gate.tag_index;
                 auto &constraints = gate.constraints;
+                auto tag = bp.add_lookup_gate(constraints);
+                BLUEPRINT_RELEASE_ASSERT(tag < assignment.selectors_amount());
 
                 // Find rows in which the gate is active
                 for (auto row = 0; row < rows; row++) {
-                    auto selector = assignment.selector(tag, row);
+                    auto selector_col = assignment.selector(tag);
+                    if (row >= selector_col.size()) {
+                        break;
+                    }
+                    auto selector = selector_col[row];
+
                     if (selector == 1) {
                         // Get the constraints in the gate
                         for (auto &constraint : constraints) {
@@ -81,25 +87,26 @@ namespace nil {
                                 }
                             }
                             if (row_index == -1) {
-                                    std::cout << "Lookup gates error" << std::endl;
-                                    std::cout << "Table: " << name << std::endl;
-                                    std::cout << "Row: " << row << std::endl;
-                                    std::cout << "lookup(0): " << first_val << std::endl;
+                                std::cout << "Lookup gates error" << std::endl;
+                                std::cout << "Table: " << name << std::endl;
+                                std::cout << "Row: " << row << std::endl;
+                                std::cout << "lookup(0): " << first_val << std::endl;
                                 return false;
-                            }
-                            for (auto i = 0; i < subtable.column_indices.size(); i++) {
-                                auto col = subtable.column_indices.at(i);
-                                auto val = table_vals.at(col).at(row_index);
-                                auto lookup_val = lookup_values.at(i);
-                                if (val != lookup_val) {
-                                    std::cout << "Lookup gates error" << std::endl;
-                                    std::cout << "Table: " << name << std::endl;
-                                    std::cout << "Row: " << row << std::endl;
-                                    std::cout << "Index: " << i << std::endl;
-                                    std::cout << "Expected: " << lookup_val << std::endl;
-                                    std::cout << "Actual: " << val << std::endl;
-                                    std::cout << "lookup(0): " << first_val << std::endl;
-                                    return false;
+                            } else {
+                                for (auto i = 0; i < subtable.column_indices.size(); i++) {
+                                    auto col = subtable.column_indices.at(i);
+                                    auto val = table_vals.at(col).at(row_index);
+                                    auto lookup_val = lookup_values.at(i);
+                                    if (val != lookup_val) {
+                                        std::cout << "Lookup gates error" << std::endl;
+                                        std::cout << "Table: " << name << std::endl;
+                                        std::cout << "Row: " << row << std::endl;
+                                        std::cout << "Index: " << i << std::endl;
+                                        std::cout << "Expected: " << lookup_val << std::endl;
+                                        std::cout << "Actual: " << val << std::endl;
+                                        std::cout << "lookup(0): " << first_val << std::endl;
+                                        return false;
+                                    }
                                 }
                             }
                         }

--- a/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/tester.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/tester.hpp
@@ -1,0 +1,106 @@
+#ifndef CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_LOOKUP_TESTER_HPP
+#define CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_LOOKUP_TESTER_HPP
+
+#include <nil/blueprint/blueprint/plonk/assignment.hpp>
+#include <nil/blueprint/blueprint/plonk/circuit.hpp>
+
+namespace nil {
+    namespace blueprint {
+
+        template<typename BlueprintFieldType, typename ArithmetizationParams>
+        bool check_lookup_tables(
+            circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+            const assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                &assignment) {
+
+            using value_type = typename BlueprintFieldType::value_type;
+            using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
+
+            // The tables
+            auto &lookup_tables = bp.get_reserved_tables();
+            auto &indices = bp.get_reserved_indices();
+
+            auto rows = assignment.rows_amount();
+
+            auto gates = bp.lookup_gates();
+
+            // For each gate
+            for (auto &gate : gates) {
+                auto tag = gate.tag_index;
+                auto &constraints = gate.constraints;
+
+                // Find rows in which the gate is active
+                for (auto row = 0; row < rows; row++) {
+                    auto selector = assignment.selector(tag, row);
+                    if (selector == 1) {
+                        // Get the constraints in the gate
+                        for (auto &constraint : constraints) {
+                            auto table_id = constraint.table_id;
+                            auto &lookup_input = constraint.lookup_input;
+
+                            // Get the lookup values
+                            std::vector<value_type> lookup_values;
+                            lookup_values.reserve(lookup_input.size());
+                            for (auto &t : lookup_input) {
+                                nil::crypto3::math::term<var> term =
+                                    boost::get<nil::crypto3::math::term<var>>(t.get_expr());
+                                BLUEPRINT_RELEASE_ASSERT(term.get_vars().size() == 1);
+                                var val = term.get_vars()[0];
+                                val.rotation += row;
+                                auto value = var_value(assignment, val);
+                                lookup_values.push_back(value);
+                            }
+
+                            // Get lookup table
+                            std::string name = "";
+                            for (auto el : indices) {
+                                if (el.second == table_id) {
+                                    name = el.first;
+                                    break;
+                                }
+                            }
+                            BLUEPRINT_RELEASE_ASSERT(name != "");
+                            auto index = name.find("/");
+                            BLUEPRINT_RELEASE_ASSERT(index != -1);
+                            auto tab_name = name.substr(0, index);
+                            auto sub_name = name.substr(index + 1);
+
+                            auto &table = lookup_tables.at(tab_name);
+                            auto &table_vals = table->get_table();
+                            auto &subtable = table->subtables.at(sub_name);
+
+                            BLUEPRINT_RELEASE_ASSERT(subtable.column_indices.size() == lookup_values.size());
+
+                            // Compare to the actual table
+                            auto row_index = -1;
+                            auto first_val = lookup_values.at(0);
+                            for (auto i = subtable.begin; i <= subtable.end; i++) {
+                                if (table_vals.at(0).at(i) == first_val) {
+                                    row_index = i;
+                                    break;
+                                }
+                            }
+                            BLUEPRINT_RELEASE_ASSERT(row_index != -1);
+                            for (auto i = 0; i < subtable.column_indices.size(); i++) {
+                                auto col = subtable.column_indices.at(i);
+                                auto val = table_vals.at(col).at(row_index);
+                                auto lookup_val = lookup_values.at(i);
+                                if (val != lookup_val) {
+                                    std::cout << "Lookup gates error" << std::endl;
+                                    std::cout << "Table: " << name << std::endl;
+                                    std::cout << "Row: " << row << std::endl;
+                                    std::cout << "Index: " << i << std::endl;
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return true;
+        }
+
+    }    // namespace blueprint
+}    // namespace nil
+#endif    // CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_LOOKUP_TESTER_HPP

--- a/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/tester.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/tester.hpp
@@ -80,7 +80,13 @@ namespace nil {
                                     break;
                                 }
                             }
-                            BLUEPRINT_RELEASE_ASSERT(row_index != -1);
+                            if (row_index == -1) {
+                                    std::cout << "Lookup gates error" << std::endl;
+                                    std::cout << "Table: " << name << std::endl;
+                                    std::cout << "Row: " << row << std::endl;
+                                    std::cout << "lookup(0): " << first_val << std::endl;
+                                return false;
+                            }
                             for (auto i = 0; i < subtable.column_indices.size(); i++) {
                                 auto col = subtable.column_indices.at(i);
                                 auto val = table_vals.at(col).at(row_index);
@@ -90,6 +96,9 @@ namespace nil {
                                     std::cout << "Table: " << name << std::endl;
                                     std::cout << "Row: " << row << std::endl;
                                     std::cout << "Index: " << i << std::endl;
+                                    std::cout << "Expected: " << lookup_val << std::endl;
+                                    std::cout << "Actual: " << val << std::endl;
+                                    std::cout << "lookup(0): " << first_val << std::endl;
                                     return false;
                                 }
                             }

--- a/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/trigonometric.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/trigonometric.hpp
@@ -1,0 +1,121 @@
+#ifndef CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_TRIGONOMETRIC_TABLE_HPP
+#define CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_TRIGONOMETRIC_TABLE_HPP
+
+#include <string>
+#include <map>
+
+#include <nil/crypto3/zk/snark/arithmetization/plonk/detail/lookup_table_definition.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/tables.hpp>
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+
+            ////////////////////////////////////////////////////////////////////
+            //////// TRIGON 16
+            ////////////////////////////////////////////////////////////////////
+
+            template<typename BlueprintFieldType>
+            class fixedpoint_trigon_16_table
+                : public nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType> {
+
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using fixedpoint_tables = FixedPointTables<BlueprintFieldType>;
+
+            public:
+                static constexpr const char *TABLE_NAME = "fixedpoint_trigon_16_table";
+                static constexpr const char *SIN_A = "sin_a";
+                static constexpr const char *SIN_B = "sin_b";
+                static constexpr const char *COS_A = "cos_a";
+                static constexpr const char *COS_B = "cos_b";
+                static constexpr const char *FULL_SIN_A = "fixedpoint_trigon_16_table/sin_a";
+                static constexpr const char *FULL_SIN_B = "fixedpoint_trigon_16_table/sin_b";
+                static constexpr const char *FULL_COS_A = "fixedpoint_trigon_16_table/cos_a";
+                static constexpr const char *FULL_COS_B = "fixedpoint_trigon_16_table/cos_b";
+
+                // TACEO_TODO this hardcoded, indices might be wrong, are they though?..
+                fixedpoint_trigon_16_table() : lookup_table_definition(TABLE_NAME) {
+                    this->subtables[SIN_A] = {{0, 1}, 0, fixedpoint_tables::SinXLen - 1};
+                    this->subtables[SIN_B] = {{0, 2}, 0, fixedpoint_tables::SinXLen - 1};
+                    this->subtables[COS_A] = {{0, 3}, 0, fixedpoint_tables::SinXLen - 1};
+                    this->subtables[COS_B] = {{0, 4}, 0, fixedpoint_tables::SinXLen - 1};
+                }
+
+                virtual void generate() {
+                    BLUEPRINT_RELEASE_ASSERT(fixedpoint_tables::RangeLen == fixedpoint_tables::SinXLen);
+                    auto input = fixedpoint_tables::get_range_table();
+                    auto sin_a = fixedpoint_tables::get_sin_a_16();
+                    auto sin_b = fixedpoint_tables::get_sin_b_16();
+                    auto cos_a = fixedpoint_tables::get_cos_a_16();
+                    auto cos_b = fixedpoint_tables::get_cos_b_16();
+                    this->_table = {input, sin_a, sin_b, cos_a, cos_b};
+                }
+
+                virtual std::size_t get_columns_number() {
+                    return 5;
+                }
+
+                virtual std::size_t get_rows_number() {
+                    return fixedpoint_tables::SinXLen;
+                }
+            };
+
+            ////////////////////////////////////////////////////////////////////
+            //////// TRIGON 32
+            ////////////////////////////////////////////////////////////////////
+
+            template<typename BlueprintFieldType>
+            class fixedpoint_trigon_32_table
+                : public nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType> {
+
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using fixedpoint_tables = FixedPointTables<BlueprintFieldType>;
+
+            public:
+                static constexpr const char *TABLE_NAME = "fixedpoint_trigon_32_table";
+                static constexpr const char *SIN_A = "sin_a";
+                static constexpr const char *SIN_B = "sin_b";
+                static constexpr const char *SIN_C = "sin_c";
+                static constexpr const char *COS_A = "cos_a";
+                static constexpr const char *COS_B = "cos_b";
+                static constexpr const char *FULL_SIN_A = "fixedpoint_trigon_32_table/sin_a";
+                static constexpr const char *FULL_SIN_B = "fixedpoint_trigon_32_table/sin_b";
+                static constexpr const char *FULL_SIN_C = "fixedpoint_trigon_32_table/sin_c";
+                static constexpr const char *FULL_COS_A = "fixedpoint_trigon_32_table/cos_a";
+                static constexpr const char *FULL_COS_B = "fixedpoint_trigon_32_table/cos_b";
+
+                // TACEO_TODO this hardcoded, indices might be wrong, are they though?..
+                fixedpoint_trigon_32_table() : lookup_table_definition(TABLE_NAME) {
+                    this->subtables[SIN_A] = {{0, 1}, 0, fixedpoint_tables::SinXLen - 1};
+                    this->subtables[SIN_B] = {{0, 2}, 0, fixedpoint_tables::SinXLen - 1};
+                    this->subtables[SIN_C] = {{0, 3}, 0, fixedpoint_tables::SinXLen - 1};
+                    this->subtables[COS_A] = {{0, 4}, 0, fixedpoint_tables::SinXLen - 1};
+                    this->subtables[COS_B] = {{0, 5}, 0, fixedpoint_tables::SinXLen - 1};
+                }
+
+                virtual void generate() {
+                    BLUEPRINT_RELEASE_ASSERT(fixedpoint_tables::RangeLen == fixedpoint_tables::SinXLen);
+                    auto input = fixedpoint_tables::get_range_table();
+                    auto sin_a = fixedpoint_tables::get_sin_a_32();
+                    auto sin_b = fixedpoint_tables::get_sin_b_32();
+                    auto sin_c = fixedpoint_tables::get_sin_c_32();
+                    auto cos_a = fixedpoint_tables::get_cos_a_32();
+                    auto cos_b = fixedpoint_tables::get_cos_b_32();
+                    this->_table = {input, sin_a, sin_b, sin_c, cos_a, cos_b};
+                }
+
+                virtual std::size_t get_columns_number() {
+                    return 6;
+                }
+
+                virtual std::size_t get_rows_number() {
+                    return fixedpoint_tables::SinXLen;
+                }
+            };
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_TRIGONOMETRIC_TABLE_HPP

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmax.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmax.hpp
@@ -10,6 +10,7 @@
 #include <nil/blueprint/basic_non_native_policy.hpp>
 
 #include "nil/blueprint/components/algebra/fixedpoint/type.hpp"
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp"
 
 namespace nil {
     namespace blueprint {
@@ -80,6 +81,9 @@ namespace nil {
 
                 using var = typename component_type::var;
                 using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using range_table = fixedpoint_range_table<BlueprintFieldType>;
 
                 value_type index_y;
                 bool select_last_index;
@@ -96,7 +100,6 @@ namespace nil {
                     return manifest;
                 }
 
-                // TACEO_TODO Update to lookup tables
                 static manifest_type get_manifest(uint8_t m1, uint8_t m2) {
                     static manifest_type manifest = manifest_type(
                         std::shared_ptr<manifest_param>(new manifest_range_param(4 + (m1 + m2), 10 + (m2 + m1))),
@@ -113,7 +116,8 @@ namespace nil {
                     }
                 }
 
-                constexpr static const std::size_t gates_amount = 1;
+                // Includes the constraints + lookup_gates
+                constexpr static const std::size_t gates_amount = 2;
                 const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, m1, m2);
 
                 struct input_type {
@@ -216,6 +220,22 @@ namespace nil {
                         return {max, index};
                     }
                 };
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result = {};
+                    auto table = std::shared_ptr<lookup_table_definition>(new range_table());
+                    result.push_back(table);
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    return lookup_tables;
+                }
+#endif
 
                 template<typename WitnessContainerType, typename ConstantContainerType,
                          typename PublicInputContainerType>
@@ -372,9 +392,45 @@ namespace nil {
                 auto constraint_6 = flag * (x - y) + y - max;
                 auto constraint_7 = flag * (index_x - index_y) + index_y - index;
 
-                // TACEO_TODO extend for lookup constraint
                 return bp.add_gate(
                     {constraint_1, constraint_2, constraint_3, constraint_4, constraint_5, constraint_6, constraint_7});
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_fixedpoint_argmax<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_argmax<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                int64_t start_row_index = 0;
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m_ = component.get_m() + 1;
+
+                const std::map<std::string, std::size_t> &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_fixedpoint_argmax<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+                using range_table =
+                    typename plonk_fixedpoint_argmax<BlueprintFieldType, ArithmetizationParams>::range_table;
+
+                std::vector<constraint_type> constraints;
+                constraints.reserve(m_);
+
+                auto table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
+
+                for (auto i = 0; i < m_; i++) {
+                    constraint_type constraint;
+                    constraint.table_id = table_id;
+
+                    // We put row=0 here and enable the selector in the correct one
+                    auto di = var(var_pos.d0.column() + i, 0);
+                    constraint.lookup_input = {di};
+                    constraints.push_back(constraint);
+                }
+
+                return bp.add_lookup_gate(constraints);
             }
 
             template<typename BlueprintFieldType, typename ArithmetizationParams>
@@ -409,11 +465,17 @@ namespace nil {
                     &instance_input,
                 const std::size_t start_row_index) {
 
-                // TACEO_TODO extend for lookup?
                 std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
 
                 // selector goes onto last row and gate uses all rows
                 assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, var_pos.d0.row());
+#endif
 
                 generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
                 generate_assignments_constant(component, assignment, instance_input, start_row_index);

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmax.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmax.hpp
@@ -404,7 +404,7 @@ namespace nil {
                     &assignment,
                 const typename plonk_fixedpoint_argmax<BlueprintFieldType, ArithmetizationParams>::input_type
                     &instance_input) {
-                int64_t start_row_index = 0;
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(start_row_index);
                 auto m_ = component.get_m() + 1;
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmax.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmax.hpp
@@ -206,14 +206,14 @@ namespace nil {
 
                     result_type(const fix_argmax &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        max = var(magic(var_pos.max), false);
-                        index = var(magic(var_pos.index), false);
+                        max = var(splat(var_pos.max), false);
+                        index = var(splat(var_pos.index), false);
                     }
 
                     result_type(const fix_argmax &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        max = var(magic(var_pos.max), false);
-                        index = var(magic(var_pos.index), false);
+                        max = var(splat(var_pos.max), false);
+                        index = var(splat(var_pos.index), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -281,9 +281,9 @@ namespace nil {
 
                 BLUEPRINT_RELEASE_ASSERT(index_x_val < index_y_val);
 
-                assignment.witness(magic(var_pos.x)) = x_val;
-                assignment.witness(magic(var_pos.y)) = y_val;
-                assignment.witness(magic(var_pos.index_x)) = index_x_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.index_x)) = index_x_val;
 
                 // decomposition of difference
                 auto d_val = x_val - y_val;
@@ -294,7 +294,7 @@ namespace nil {
                 BLUEPRINT_RELEASE_ASSERT(!sign_);
                 // is ok because d0_val is at least of size 4 and the biggest we have is 32.32
                 BLUEPRINT_RELEASE_ASSERT(d0_val.size() >= m);
-                assignment.witness(magic(var_pos.s)) = sign ? -one : one;
+                assignment.witness(splat(var_pos.s)) = sign ? -one : one;
 
                 // Additional limb due to potential overflow of d_val
                 if (d0_val.size() > m) {
@@ -311,25 +311,25 @@ namespace nil {
                 // equal, flag and max
                 bool eq = d_val == 0;
 
-                assignment.witness(magic(var_pos.eq)) = typename BlueprintFieldType::value_type((uint64_t)eq);
+                assignment.witness(splat(var_pos.eq)) = typename BlueprintFieldType::value_type((uint64_t)eq);
 
                 // if eq:  Does not matter what to put here
-                assignment.witness(magic(var_pos.inv)) = eq ? BlueprintFieldType::value_type::zero() : d_val.inversed();
+                assignment.witness(splat(var_pos.inv)) = eq ? BlueprintFieldType::value_type::zero() : d_val.inversed();
 
                 // Which component to we have
                 if (component.select_last_index) {
                     // We have to evaluate x > y
                     bool gt = !eq && !sign;
-                    assignment.witness(magic(var_pos.flag)) = typename BlueprintFieldType::value_type((uint64_t)gt);
-                    assignment.witness(magic(var_pos.max)) = gt ? x_val : y_val;
-                    assignment.witness(magic(var_pos.index)) = gt ? index_x_val : index_y_val;
+                    assignment.witness(splat(var_pos.flag)) = typename BlueprintFieldType::value_type((uint64_t)gt);
+                    assignment.witness(splat(var_pos.max)) = gt ? x_val : y_val;
+                    assignment.witness(splat(var_pos.index)) = gt ? index_x_val : index_y_val;
 
                 } else {
                     // We have to evaluate x >= y
                     bool geq = !sign || eq;
-                    assignment.witness(magic(var_pos.flag)) = typename BlueprintFieldType::value_type((uint64_t)geq);
-                    assignment.witness(magic(var_pos.max)) = geq ? x_val : y_val;
-                    assignment.witness(magic(var_pos.index)) = geq ? index_x_val : index_y_val;
+                    assignment.witness(splat(var_pos.flag)) = typename BlueprintFieldType::value_type((uint64_t)geq);
+                    assignment.witness(splat(var_pos.max)) = geq ? x_val : y_val;
+                    assignment.witness(splat(var_pos.index)) = geq ? index_x_val : index_y_val;
                 }
 
                 return typename plonk_fixedpoint_argmax<BlueprintFieldType, ArithmetizationParams>::result_type(
@@ -352,7 +352,7 @@ namespace nil {
 
                 auto m = component.get_m();
 
-                auto d0 = nil::crypto3::math::expression(var(magic(var_pos.d0)));
+                auto d0 = nil::crypto3::math::expression(var(splat(var_pos.d0)));
                 for (auto i = 1; i < m; i++) {
                     d0 += var(var_pos.d0.column() + i, var_pos.d0.row()) * (1ULL << (16 * i));
                 }
@@ -361,16 +361,16 @@ namespace nil {
                 tmp *= 1ULL << 16;
                 d0 += var(var_pos.d0.column() + m, var_pos.d0.row()) * tmp;
 
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
-                auto index_x = var(magic(var_pos.index_x));
-                auto index_y = var(magic(var_pos.index_y), true, var::column_type::constant);
-                auto max = var(magic(var_pos.max));
-                auto index = var(magic(var_pos.index));
-                auto flag = var(magic(var_pos.flag));
-                auto eq = var(magic(var_pos.eq));
-                auto inv = var(magic(var_pos.inv));
-                auto s = var(magic(var_pos.s));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto index_x = var(splat(var_pos.index_x));
+                auto index_y = var(splat(var_pos.index_y), true, var::column_type::constant);
+                auto max = var(splat(var_pos.max));
+                auto index = var(splat(var_pos.index));
+                auto flag = var(splat(var_pos.flag));
+                auto eq = var(splat(var_pos.eq));
+                auto inv = var(splat(var_pos.inv));
+                auto s = var(splat(var_pos.s));
 
                 auto constraint_1 = x - y - s * d0;
                 auto constraint_2 = (s - 1) * (s + 1);
@@ -447,9 +447,9 @@ namespace nil {
 
                 using var = typename plonk_fixedpoint_argmax<BlueprintFieldType, ArithmetizationParams>::var;
 
-                var x = var(magic(var_pos.x), false);
-                var y = var(magic(var_pos.y), false);
-                var index_x = var(magic(var_pos.index_x), false);
+                var x = var(splat(var_pos.x), false);
+                var y = var(splat(var_pos.y), false);
+                var index_x = var(splat(var_pos.index_x), false);
                 bp.add_copy_constraint({instance_input.x, x});
                 bp.add_copy_constraint({instance_input.y, y});
                 bp.add_copy_constraint({instance_input.index_x, index_x});
@@ -495,7 +495,7 @@ namespace nil {
 
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
-                assignment.constant(magic(var_pos.index_y)) = component.index_y;
+                assignment.constant(splat(var_pos.index_y)) = component.index_y;
             }
 
         }    // namespace components

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmax.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmax.hpp
@@ -20,7 +20,7 @@ namespace nil {
             // (https://github.com/onnx/onnx/blob/main/docs/Operators.md#ArgMax), the select_last_index attribute
             // decides what should happen during a tie. We set this attribute during initialization of the gadget, and
             // do *not* prove it.
-            // This gadget also assumes, that index_x < index_y!
+            // This gadget also assumes that index_x < index_y!
             // Index_y is a constant, while index_x is a witness.
 
             /**

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmin.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmin.hpp
@@ -10,6 +10,7 @@
 #include <nil/blueprint/basic_non_native_policy.hpp>
 
 #include "nil/blueprint/components/algebra/fixedpoint/type.hpp"
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp"
 
 namespace nil {
     namespace blueprint {
@@ -80,6 +81,9 @@ namespace nil {
 
                 using var = typename component_type::var;
                 using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using range_table = fixedpoint_range_table<BlueprintFieldType>;
 
                 value_type index_y;
                 bool select_last_index;
@@ -96,7 +100,6 @@ namespace nil {
                     return manifest;
                 }
 
-                // TACEO_TODO Update to lookup tables
                 static manifest_type get_manifest(uint8_t m1, uint8_t m2) {
                     static manifest_type manifest = manifest_type(
                         std::shared_ptr<manifest_param>(new manifest_range_param(4 + (m1 + m2), 10 + (m2 + m1))),
@@ -113,7 +116,8 @@ namespace nil {
                     }
                 }
 
-                constexpr static const std::size_t gates_amount = 1;
+                // Includes the constraints + lookup_gates
+                constexpr static const std::size_t gates_amount = 2;
                 const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, m1, m2);
 
                 struct input_type {
@@ -216,6 +220,22 @@ namespace nil {
                         return {min, index};
                     }
                 };
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result = {};
+                    auto table = std::shared_ptr<lookup_table_definition>(new range_table());
+                    result.push_back(table);
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    return lookup_tables;
+                }
+#endif
 
                 template<typename WitnessContainerType, typename ConstantContainerType,
                          typename PublicInputContainerType>
@@ -372,9 +392,45 @@ namespace nil {
                 auto constraint_6 = flag * (x - y) + y - min;
                 auto constraint_7 = flag * (index_x - index_y) + index_y - index;
 
-                // TACEO_TODO extend for lookup constraint
                 return bp.add_gate(
                     {constraint_1, constraint_2, constraint_3, constraint_4, constraint_5, constraint_6, constraint_7});
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_fixedpoint_argmin<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_argmin<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                int64_t start_row_index = 0;
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m_ = component.get_m() + 1;
+
+                const std::map<std::string, std::size_t> &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_fixedpoint_argmin<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+                using range_table =
+                    typename plonk_fixedpoint_argmin<BlueprintFieldType, ArithmetizationParams>::range_table;
+
+                std::vector<constraint_type> constraints;
+                constraints.reserve(m_);
+
+                auto table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
+
+                for (auto i = 0; i < m_; i++) {
+                    constraint_type constraint;
+                    constraint.table_id = table_id;
+
+                    // We put row=0 here and enable the selector in the correct one
+                    auto di = var(var_pos.d0.column() + i, 0);
+                    constraint.lookup_input = {di};
+                    constraints.push_back(constraint);
+                }
+
+                return bp.add_lookup_gate(constraints);
             }
 
             template<typename BlueprintFieldType, typename ArithmetizationParams>
@@ -414,6 +470,13 @@ namespace nil {
 
                 // selector goes onto last row and gate uses all rows
                 assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, var_pos.d0.row());
+#endif
 
                 generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
                 generate_assignments_constant(component, assignment, instance_input, start_row_index);

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmin.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmin.hpp
@@ -465,7 +465,6 @@ namespace nil {
                     &instance_input,
                 const std::size_t start_row_index) {
 
-                // TACEO_TODO extend for lookup?
                 std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
 
                 // selector goes onto last row and gate uses all rows

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmin.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmin.hpp
@@ -404,7 +404,7 @@ namespace nil {
                     &assignment,
                 const typename plonk_fixedpoint_argmin<BlueprintFieldType, ArithmetizationParams>::input_type
                     &instance_input) {
-                int64_t start_row_index = 0;
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(start_row_index);
                 auto m_ = component.get_m() + 1;
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmin.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmin.hpp
@@ -206,14 +206,14 @@ namespace nil {
 
                     result_type(const fix_argmin &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        min = var(magic(var_pos.min), false);
-                        index = var(magic(var_pos.index), false);
+                        min = var(splat(var_pos.min), false);
+                        index = var(splat(var_pos.index), false);
                     }
 
                     result_type(const fix_argmin &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        min = var(magic(var_pos.min), false);
-                        index = var(magic(var_pos.index), false);
+                        min = var(splat(var_pos.min), false);
+                        index = var(splat(var_pos.index), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -281,9 +281,9 @@ namespace nil {
 
                 BLUEPRINT_RELEASE_ASSERT(index_x_val < index_y_val);
 
-                assignment.witness(magic(var_pos.x)) = x_val;
-                assignment.witness(magic(var_pos.y)) = y_val;
-                assignment.witness(magic(var_pos.index_x)) = index_x_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.index_x)) = index_x_val;
 
                 // decomposition of difference
                 auto d_val = x_val - y_val;
@@ -294,7 +294,7 @@ namespace nil {
                 BLUEPRINT_RELEASE_ASSERT(!sign_);
                 // is ok because d0_val is at least of size 4 and the biggest we have is 32.32
                 BLUEPRINT_RELEASE_ASSERT(d0_val.size() >= m);
-                assignment.witness(magic(var_pos.s)) = sign ? -one : one;
+                assignment.witness(splat(var_pos.s)) = sign ? -one : one;
 
                 // Additional limb due to potential overflow of d_val
                 if (d0_val.size() > m) {
@@ -311,25 +311,25 @@ namespace nil {
                 // equal, flag and min
                 bool eq = d_val == 0;
 
-                assignment.witness(magic(var_pos.eq)) = typename BlueprintFieldType::value_type((uint64_t)eq);
+                assignment.witness(splat(var_pos.eq)) = typename BlueprintFieldType::value_type((uint64_t)eq);
 
                 // if eq:  Does not matter what to put here
-                assignment.witness(magic(var_pos.inv)) = eq ? BlueprintFieldType::value_type::zero() : d_val.inversed();
+                assignment.witness(splat(var_pos.inv)) = eq ? BlueprintFieldType::value_type::zero() : d_val.inversed();
 
                 // Which component to we have
                 if (component.select_last_index) {
                     // We have to evaluate x < y
                     bool lt = !eq && sign;
-                    assignment.witness(magic(var_pos.flag)) = typename BlueprintFieldType::value_type((uint64_t)lt);
-                    assignment.witness(magic(var_pos.min)) = lt ? x_val : y_val;
-                    assignment.witness(magic(var_pos.index)) = lt ? index_x_val : index_y_val;
+                    assignment.witness(splat(var_pos.flag)) = typename BlueprintFieldType::value_type((uint64_t)lt);
+                    assignment.witness(splat(var_pos.min)) = lt ? x_val : y_val;
+                    assignment.witness(splat(var_pos.index)) = lt ? index_x_val : index_y_val;
 
                 } else {
                     // We have to evaluate x <= y
                     bool leq = sign || eq;
-                    assignment.witness(magic(var_pos.flag)) = typename BlueprintFieldType::value_type((uint64_t)leq);
-                    assignment.witness(magic(var_pos.min)) = leq ? x_val : y_val;
-                    assignment.witness(magic(var_pos.index)) = leq ? index_x_val : index_y_val;
+                    assignment.witness(splat(var_pos.flag)) = typename BlueprintFieldType::value_type((uint64_t)leq);
+                    assignment.witness(splat(var_pos.min)) = leq ? x_val : y_val;
+                    assignment.witness(splat(var_pos.index)) = leq ? index_x_val : index_y_val;
                 }
 
                 return typename plonk_fixedpoint_argmin<BlueprintFieldType, ArithmetizationParams>::result_type(
@@ -352,7 +352,7 @@ namespace nil {
 
                 auto m = component.get_m();
 
-                auto d0 = nil::crypto3::math::expression(var(magic(var_pos.d0)));
+                auto d0 = nil::crypto3::math::expression(var(splat(var_pos.d0)));
                 for (auto i = 1; i < m; i++) {
                     d0 += var(var_pos.d0.column() + i, var_pos.d0.row()) * (1ULL << (16 * i));
                 }
@@ -361,16 +361,16 @@ namespace nil {
                 tmp *= 1ULL << 16;
                 d0 += var(var_pos.d0.column() + m, var_pos.d0.row()) * tmp;
 
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
-                auto index_x = var(magic(var_pos.index_x));
-                auto index_y = var(magic(var_pos.index_y), true, var::column_type::constant);
-                auto min = var(magic(var_pos.min));
-                auto index = var(magic(var_pos.index));
-                auto flag = var(magic(var_pos.flag));
-                auto eq = var(magic(var_pos.eq));
-                auto inv = var(magic(var_pos.inv));
-                auto s = var(magic(var_pos.s));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto index_x = var(splat(var_pos.index_x));
+                auto index_y = var(splat(var_pos.index_y), true, var::column_type::constant);
+                auto min = var(splat(var_pos.min));
+                auto index = var(splat(var_pos.index));
+                auto flag = var(splat(var_pos.flag));
+                auto eq = var(splat(var_pos.eq));
+                auto inv = var(splat(var_pos.inv));
+                auto s = var(splat(var_pos.s));
 
                 auto constraint_1 = x - y - s * d0;
                 auto constraint_2 = (s - 1) * (s + 1);
@@ -447,9 +447,9 @@ namespace nil {
 
                 using var = typename plonk_fixedpoint_argmin<BlueprintFieldType, ArithmetizationParams>::var;
 
-                var x = var(magic(var_pos.x), false);
-                var y = var(magic(var_pos.y), false);
-                var index_x = var(magic(var_pos.index_x), false);
+                var x = var(splat(var_pos.x), false);
+                var y = var(splat(var_pos.y), false);
+                var index_x = var(splat(var_pos.index_x), false);
                 bp.add_copy_constraint({instance_input.x, x});
                 bp.add_copy_constraint({instance_input.y, y});
                 bp.add_copy_constraint({instance_input.index_x, index_x});
@@ -495,7 +495,7 @@ namespace nil {
 
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
-                assignment.constant(magic(var_pos.index_y)) = component.index_y;
+                assignment.constant(splat(var_pos.index_y)) = component.index_y;
             }
 
         }    // namespace components

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmin.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/argmin.hpp
@@ -20,7 +20,7 @@ namespace nil {
             // (https://github.com/onnx/onnx/blob/main/docs/Operators.md#ArgMin), the select_last_index attribute
             // decides what should happen during a tie. We set this attribute during initialization of the gadget, and
             // do *not* prove it.
-            // This gadget also assumes, that index_x < index_y!
+            // This gadget also assumes that index_x < index_y!
             // Index_y is a constant, while index_x is a witness.
 
             /**

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/boolean.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/boolean.hpp
@@ -1,0 +1,333 @@
+#ifndef CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_BOOLEAN_HPP
+#define CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_BOOLEAN_HPP
+
+#include <nil/crypto3/zk/snark/arithmetization/plonk/constraint_system.hpp>
+
+#include <nil/blueprint/blueprint/plonk/assignment.hpp>
+#include <nil/blueprint/blueprint/plonk/circuit.hpp>
+#include <nil/blueprint/component.hpp>
+#include <nil/blueprint/manifest.hpp>
+#include <nil/blueprint/basic_non_native_policy.hpp>
+
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/boolean.hpp"
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+
+            template<typename ArithmetizationType, typename FieldType, typename NonNativePolicyType>
+            class fix_boolean;
+
+            /**
+             * This component exists for fun, demo, and experimental reasons (because its lookup table is small).
+             * (and doesn't actually use fixed point representation, just the values 0 and 1 of the underlying field)
+             */
+            template<typename BlueprintFieldType, typename ArithmetizationParams, typename NonNativePolicyType>
+            class fix_boolean<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                              BlueprintFieldType, NonNativePolicyType>
+                : public plonk_component<BlueprintFieldType, ArithmetizationParams, 0, 0> {
+
+            private:
+                uint8_t m1;    // Pre-comma 16-bit limbs
+                uint8_t m2;    // Post-comma 16-bit limbs
+
+                static uint8_t M(uint8_t m) {
+                    if (m == 0 || m > 2) {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+                    return m;
+                }
+
+            public:
+            private:
+            public:
+                uint64_t get_delta() const {
+                    return 1ULL << (16 * this->m2);
+                }
+
+                uint8_t get_m2() const {
+                    return this->m2;
+                }
+
+                uint8_t get_m1() const {
+                    return this->m1;
+                }
+
+                uint8_t get_m() const {
+                    return this->m1 + this->m2;
+                }
+
+                constexpr static std::size_t get_witness_columns(uint8_t m2) {
+                    return 5;
+                }
+
+                using component_type = plonk_component<BlueprintFieldType, ArithmetizationParams, 0, 0>;
+
+                using var = typename component_type::var;
+                using value_type = typename BlueprintFieldType::value_type;
+                using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+
+                class gate_manifest_type : public component_gate_manifest {
+                public:
+                    std::uint32_t gates_amount() const override {
+                        return fix_boolean::gates_amount;
+                    }
+                };
+
+                static gate_manifest get_gate_manifest(std::size_t witness_amount, std::size_t lookup_column_amount) {
+                    static gate_manifest manifest = gate_manifest(gate_manifest_type());
+                    return manifest;
+                }
+
+                // TACEO_TODO Update to lookup tables
+                static manifest_type get_manifest(uint8_t m2) {
+                    static manifest_type manifest = manifest_type(
+                        std::shared_ptr<manifest_param>(new manifest_single_value_param(get_witness_columns(m2))),
+                        false);
+                    return manifest;
+                }
+
+                constexpr static std::size_t get_rows_amount(uint8_t m1, uint8_t m2) {
+                    return 1;
+                }
+
+                constexpr static const std::size_t gates_amount = 2;
+                const std::size_t rows_amount = get_rows_amount(this->m1, this->m2);
+
+                struct input_type {
+                    var x = var(0, 0, false);
+                    var y = var(0, 0, false);
+
+                    std::vector<var> all_vars() const {
+                        return {x, y};
+                    }
+                };
+
+                struct result_type {
+                    var and_ = var(0, 0, false);
+                    var or_ = var(0, 0, false);
+                    var xor_ = var(0, 0, false);
+                    result_type(const fix_boolean &component, std::uint32_t start_row_index) {
+                        and_ = var(component.W(2), start_row_index, false);
+                        or_ = var(component.W(3), start_row_index, false);
+                        xor_ = var(component.W(4), start_row_index, false);
+                    }
+
+                    result_type(const fix_boolean &component, std::size_t start_row_index) {
+                        and_ = var(component.W(2), start_row_index, false);
+                        or_ = var(component.W(3), start_row_index, false);
+                        xor_ = var(component.W(4), start_row_index, false);
+                    }
+
+                    std::vector<var> all_vars() const {
+                        return {and_, or_, xor_};
+                    }
+                };
+
+// Allows disabling lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result = {};
+                    auto table =
+                        std::shared_ptr<lookup_table_definition>(new fixedpoint_boolean_table<BlueprintFieldType>());
+                    result.push_back(table);
+
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables = {};
+                    lookup_tables[fixedpoint_boolean_table<BlueprintFieldType>::FULL_AND] = 0;    // REQUIRED_TABLE
+                    lookup_tables[fixedpoint_boolean_table<BlueprintFieldType>::FULL_OR] = 0;     // REQUIRED_TABLE
+                    lookup_tables[fixedpoint_boolean_table<BlueprintFieldType>::FULL_XOR] = 0;    // REQUIRED_TABLE
+
+                    return lookup_tables;
+                }
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+
+                template<typename ContainerType>
+                explicit fix_boolean(ContainerType witness, uint8_t m1, uint8_t m2) :
+                    component_type(witness, {}, {}, get_manifest(m2)), m1(M(m1)), m2(M(m2)) {};
+
+                template<typename WitnessContainerType, typename ConstantContainerType,
+                         typename PublicInputContainerType>
+                fix_boolean(WitnessContainerType witness, ConstantContainerType constant,
+                            PublicInputContainerType public_input, uint8_t m1, uint8_t m2) :
+                    component_type(witness, constant, public_input, get_manifest(m2)),
+                    m1(M(m1)), m2(M(m2)) {};
+
+                fix_boolean(
+                    std::initializer_list<typename component_type::witness_container_type::value_type> witnesses,
+                    std::initializer_list<typename component_type::constant_container_type::value_type> constants,
+                    std::initializer_list<typename component_type::public_input_container_type::value_type>
+                        public_inputs,
+                    uint8_t m1, uint8_t m2) :
+                    component_type(witnesses, constants, public_inputs, get_manifest(m2)),
+                    m1(M(m1)), m2(M(m2)) {};
+            };
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            using plonk_fixedpoint_boolean =
+                fix_boolean<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                            BlueprintFieldType, basic_non_native_policy<BlueprintFieldType>>;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams>::result_type
+                generate_assignments(
+                    const plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams> &component,
+                    assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                        &assignment,
+                    const typename plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams>::input_type
+                        instance_input,
+                    const std::uint32_t start_row_index) {
+
+                using value_type = typename BlueprintFieldType::value_type;
+
+                auto one = value_type::one();
+                auto zero = value_type::zero();
+
+                auto x_val = var_value(assignment, instance_input.x);
+                auto y_val = var_value(assignment, instance_input.y);
+                auto and_val = x_val * y_val;
+                auto or_val = x_val == one ? x_val : y_val;
+                auto xor_val = x_val == y_val ? zero : one;
+
+                assignment.witness(component.W(0), start_row_index) = x_val;
+                assignment.witness(component.W(1), start_row_index) = y_val;
+                assignment.witness(component.W(2), start_row_index) = and_val;
+                assignment.witness(component.W(3), start_row_index) = or_val;
+                assignment.witness(component.W(4), start_row_index) = xor_val;
+
+                return typename plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::vector<crypto3::zk::snark::plonk_constraint<BlueprintFieldType>> get_constraints(
+                const plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                using var = typename plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams>::var;
+                auto a = var(component.W(0), start_row_index);
+
+                auto constraint_1 = a * (a - 1);    // dummy constraint to have at least one for keeping our structure
+                return {constraint_1};
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_gates(
+                const plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+
+                auto constraints = get_constraints(component, bp, assignment, instance_input);
+                return bp.add_gate(constraints);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            void generate_copy_constraints(
+                const plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input,
+                const std::size_t start_row_index) {
+                using var = typename plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams>::var;
+                var x = var(component.W(0), start_row_index, false);
+                var y = var(component.W(1), start_row_index, false);
+                bp.add_copy_constraint({instance_input.x, x});
+                bp.add_copy_constraint({instance_input.y, y});
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                auto m2 = component.get_m2();
+
+                const std::map<std::string, std::size_t> &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+
+                auto boolean_table_id_and =
+                    lookup_tables_indices.at(fixedpoint_boolean_table<BlueprintFieldType>::FULL_AND);
+                auto boolean_table_id_or =
+                    lookup_tables_indices.at(fixedpoint_boolean_table<BlueprintFieldType>::FULL_OR);
+                auto boolean_table_id_xor =
+                    lookup_tables_indices.at(fixedpoint_boolean_table<BlueprintFieldType>::FULL_XOR);
+
+                auto x = var(component.W(0), start_row_index);
+                auto y = var(component.W(1), start_row_index);
+                auto and_ = var(component.W(2), start_row_index);
+                auto or_ = var(component.W(3), start_row_index);
+                auto xor_ = var(component.W(4), start_row_index);
+
+                std::vector<constraint_type> constraints;
+                {    // and
+                    constraint_type constraint;
+                    constraint.table_id = boolean_table_id_and;
+                    constraint.lookup_input = {x, y, and_};
+                    constraints.push_back(constraint);
+                }
+                {    // or
+                    constraint_type constraint;
+                    constraint.table_id = boolean_table_id_or;
+                    constraint.lookup_input = {x, y, or_};
+                    constraints.push_back(constraint);
+                }
+                {    // xor
+                    constraint_type constraint;
+                    constraint.table_id = boolean_table_id_xor;
+                    constraint.lookup_input = {x, y, xor_};
+                    constraints.push_back(constraint);
+                }
+                return bp.add_lookup_gate(constraints);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams>::result_type generate_circuit(
+                const plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input,
+                const std::size_t start_row_index) {
+
+                // TACEO_TODO extend for lookup?
+                std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
+
+                assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
+
+// Allows disabling lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, start_row_index + component.rows_amount - 1);
+#endif
+                generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
+
+                return typename plonk_fixedpoint_boolean<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_BOOLEAN_HPP

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp.hpp
@@ -87,7 +87,6 @@ namespace nil {
                     return manifest;
                 }
 
-                // TACEO_TODO Update to lookup tables
                 static manifest_type get_manifest(uint8_t m1, uint8_t m2) {
                     static manifest_type manifest = manifest_type(
                         std::shared_ptr<manifest_param>(new manifest_single_value_param(get_witness_columns(m1, m2))),

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp.hpp
@@ -330,7 +330,7 @@ namespace nil {
                     &assignment,
                 const typename plonk_fixedpoint_cmp<BlueprintFieldType, ArithmetizationParams>::input_type
                     &instance_input) {
-                int64_t start_row_index = 0;
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(start_row_index);
                 auto m_ = component.get_m() + 1;
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp.hpp
@@ -274,7 +274,7 @@ namespace nil {
                 const typename plonk_fixedpoint_cmp<BlueprintFieldType, ArithmetizationParams>::input_type
                     &instance_input) {
 
-                int64_t start_row_index = 1 - component.rows_amount;
+                int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
                 using var = typename plonk_fixedpoint_cmp<BlueprintFieldType, ArithmetizationParams>::var;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp.hpp
@@ -147,16 +147,16 @@ namespace nil {
 
                     result_type(const fix_cmp &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        eq = var(magic(var_pos.eq), false);
-                        lt = var(magic(var_pos.lt), false);
-                        gt = var(magic(var_pos.gt), false);
+                        eq = var(splat(var_pos.eq), false);
+                        lt = var(splat(var_pos.lt), false);
+                        gt = var(splat(var_pos.gt), false);
                     }
 
                     result_type(const fix_cmp &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        eq = var(magic(var_pos.eq), false);
-                        lt = var(magic(var_pos.lt), false);
-                        gt = var(magic(var_pos.gt), false);
+                        eq = var(splat(var_pos.eq), false);
+                        lt = var(splat(var_pos.lt), false);
+                        gt = var(splat(var_pos.gt), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -223,8 +223,8 @@ namespace nil {
                 auto y_val = var_value(assignment, instance_input.y);
                 auto d_val = x_val - y_val;
 
-                assignment.witness(magic(var_pos.x)) = x_val;
-                assignment.witness(magic(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
 
                 std::vector<uint16_t> d0_val;
 
@@ -238,13 +238,13 @@ namespace nil {
                 auto eq_val = typename BlueprintFieldType::value_type(static_cast<uint64_t>(eq));
                 auto lt_val = typename BlueprintFieldType::value_type(static_cast<uint64_t>(sign));
                 auto gt_val = typename BlueprintFieldType::value_type((uint64_t)(!eq && !sign));
-                assignment.witness(magic(var_pos.eq)) = eq_val;
-                assignment.witness(magic(var_pos.lt)) = lt_val;
-                assignment.witness(magic(var_pos.gt)) = gt_val;
-                assignment.witness(magic(var_pos.s)) = sign ? -one : one;
+                assignment.witness(splat(var_pos.eq)) = eq_val;
+                assignment.witness(splat(var_pos.lt)) = lt_val;
+                assignment.witness(splat(var_pos.gt)) = gt_val;
+                assignment.witness(splat(var_pos.s)) = sign ? -one : one;
 
                 // if eq:  Does not matter what to put here
-                assignment.witness(magic(var_pos.inv)) = eq ? zero : d_val.inversed();
+                assignment.witness(splat(var_pos.inv)) = eq ? zero : d_val.inversed();
 
                 // Additional limb due to potential overflow of diff
                 // FixedPointHelper::decompose creates a vector whose size is a multiple of 4.
@@ -280,7 +280,7 @@ namespace nil {
                 using var = typename plonk_fixedpoint_cmp<BlueprintFieldType, ArithmetizationParams>::var;
                 auto m = component.get_m();
 
-                auto d = nil::crypto3::math::expression(var(magic(var_pos.d0)));
+                auto d = nil::crypto3::math::expression(var(splat(var_pos.d0)));
                 for (auto i = 1; i < m; i++) {
                     d += var(var_pos.d0.column() + i, var_pos.d0.row()) * (1ULL << (16 * i));
                 }
@@ -289,13 +289,13 @@ namespace nil {
                 tmp *= 1ULL << 16;
                 d += var(var_pos.d0.column() + m, var_pos.d0.row()) * tmp;
 
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
-                auto eq = var(magic(var_pos.eq));
-                auto lt = var(magic(var_pos.lt));
-                auto gt = var(magic(var_pos.gt));
-                auto s = var(magic(var_pos.s));
-                auto inv = var(magic(var_pos.inv));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto eq = var(splat(var_pos.eq));
+                auto lt = var(splat(var_pos.lt));
+                auto gt = var(splat(var_pos.gt));
+                auto s = var(splat(var_pos.s));
+                auto inv = var(splat(var_pos.inv));
                 auto inv2 = typename BlueprintFieldType::value_type(2).inversed();
 
                 auto constraint_1 = x - y - s * d;
@@ -370,8 +370,8 @@ namespace nil {
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
                 using var = typename plonk_fixedpoint_cmp<BlueprintFieldType, ArithmetizationParams>::var;
-                var x = var(magic(var_pos.x), false);
-                var y = var(magic(var_pos.y), false);
+                var x = var(splat(var_pos.x), false);
+                var y = var(splat(var_pos.y), false);
                 bp.add_copy_constraint({instance_input.x, x});
                 bp.add_copy_constraint({instance_input.y, y});
             }

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp_extended.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp_extended.hpp
@@ -153,22 +153,22 @@ namespace nil {
                     var geq = var(0, 0, false);
                     result_type(const fix_cmp_extended &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        eq = var(magic(var_pos.eq), false);
-                        lt = var(magic(var_pos.lt), false);
-                        gt = var(magic(var_pos.gt), false);
-                        neq = var(magic(var_pos.neq), false);
-                        leq = var(magic(var_pos.leq), false);
-                        geq = var(magic(var_pos.geq), false);
+                        eq = var(splat(var_pos.eq), false);
+                        lt = var(splat(var_pos.lt), false);
+                        gt = var(splat(var_pos.gt), false);
+                        neq = var(splat(var_pos.neq), false);
+                        leq = var(splat(var_pos.leq), false);
+                        geq = var(splat(var_pos.geq), false);
                     }
 
                     result_type(const fix_cmp_extended &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        eq = var(magic(var_pos.eq), false);
-                        lt = var(magic(var_pos.lt), false);
-                        gt = var(magic(var_pos.gt), false);
-                        neq = var(magic(var_pos.neq), false);
-                        leq = var(magic(var_pos.leq), false);
-                        geq = var(magic(var_pos.geq), false);
+                        eq = var(splat(var_pos.eq), false);
+                        lt = var(splat(var_pos.lt), false);
+                        gt = var(splat(var_pos.gt), false);
+                        neq = var(splat(var_pos.neq), false);
+                        leq = var(splat(var_pos.leq), false);
+                        geq = var(splat(var_pos.geq), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -228,9 +228,9 @@ namespace nil {
                 auto result = generate_assignments(cmp_comp, assignment, instance_input, start_row_index);
 
                 auto one = BlueprintFieldType::value_type::one();
-                assignment.witness(magic(var_pos.neq)) = one - var_value(assignment, result.eq);
-                assignment.witness(magic(var_pos.leq)) = one - var_value(assignment, result.gt);
-                assignment.witness(magic(var_pos.geq)) = one - var_value(assignment, result.lt);
+                assignment.witness(splat(var_pos.neq)) = one - var_value(assignment, result.eq);
+                assignment.witness(splat(var_pos.leq)) = one - var_value(assignment, result.gt);
+                assignment.witness(splat(var_pos.geq)) = one - var_value(assignment, result.lt);
 
                 return typename plonk_fixedpoint_cmp_extended<BlueprintFieldType, ArithmetizationParams>::result_type(
                     component, start_row_index);
@@ -253,12 +253,12 @@ namespace nil {
                 auto cmp_comp = component.get_cmp_component();
                 auto constraints = get_constraints(cmp_comp, bp, assignment, instance_input);
 
-                auto eq = var(magic(var_pos.eq));
-                auto lt = var(magic(var_pos.lt));
-                auto gt = var(magic(var_pos.gt));
-                auto neq = var(magic(var_pos.neq));
-                auto leq = var(magic(var_pos.leq));
-                auto geq = var(magic(var_pos.geq));
+                auto eq = var(splat(var_pos.eq));
+                auto lt = var(splat(var_pos.lt));
+                auto gt = var(splat(var_pos.gt));
+                auto neq = var(splat(var_pos.neq));
+                auto leq = var(splat(var_pos.leq));
+                auto geq = var(splat(var_pos.geq));
 
                 auto one = BlueprintFieldType::value_type::one();
                 auto constraint_1 = eq + neq - one;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp_extended.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp_extended.hpp
@@ -245,7 +245,7 @@ namespace nil {
                 const typename plonk_fixedpoint_cmp_extended<BlueprintFieldType, ArithmetizationParams>::input_type
                     &instance_input) {
 
-                int64_t start_row_index = 1 - component.rows_amount;
+                int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
                 using var = typename plonk_fixedpoint_cmp_extended<BlueprintFieldType, ArithmetizationParams>::var;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp_extended.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp_extended.hpp
@@ -74,6 +74,8 @@ namespace nil {
 
                 using var = typename component_type::var;
                 using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
 
                 class gate_manifest_type : public component_gate_manifest {
                 public:
@@ -103,7 +105,8 @@ namespace nil {
                     return 1;
                 }
 
-                constexpr static const std::size_t gates_amount = 1;
+                // Includes the constraints + lookup_gates
+                constexpr static const std::size_t gates_amount = 2;
                 const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0);
 
                 using input_type = typename cmp_component::input_type;
@@ -172,6 +175,17 @@ namespace nil {
                         return {eq, lt, gt, neq, leq, geq};
                     }
                 };
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    return cmp.component_custom_lookup_tables();
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    return cmp.component_lookup_tables();
+                }
+#endif
 
                 template<typename ContainerType>
                 explicit fix_cmp_extended(ContainerType witness, uint8_t m1, uint8_t m2) :
@@ -287,6 +301,13 @@ namespace nil {
                 std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
 
                 assignment.enable_selector(selector_index, start_row_index);
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                auto cmp_comp = component.get_cmp_component();
+                std::size_t lookup_selector_index = generate_lookup_gates(cmp_comp, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, start_row_index);
+#endif
 
                 generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp_min_max.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp_min_max.hpp
@@ -151,20 +151,20 @@ namespace nil {
                     var max = var(0, 0, false);
                     result_type(const fix_cmp_min_max &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        eq = var(magic(var_pos.eq), false);
-                        lt = var(magic(var_pos.lt), false);
-                        gt = var(magic(var_pos.gt), false);
-                        min = var(magic(var_pos.min), false);
-                        max = var(magic(var_pos.max), false);
+                        eq = var(splat(var_pos.eq), false);
+                        lt = var(splat(var_pos.lt), false);
+                        gt = var(splat(var_pos.gt), false);
+                        min = var(splat(var_pos.min), false);
+                        max = var(splat(var_pos.max), false);
                     }
 
                     result_type(const fix_cmp_min_max &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        eq = var(magic(var_pos.eq), false);
-                        lt = var(magic(var_pos.lt), false);
-                        gt = var(magic(var_pos.gt), false);
-                        min = var(magic(var_pos.min), false);
-                        max = var(magic(var_pos.max), false);
+                        eq = var(splat(var_pos.eq), false);
+                        lt = var(splat(var_pos.lt), false);
+                        gt = var(splat(var_pos.gt), false);
+                        min = var(splat(var_pos.min), false);
+                        max = var(splat(var_pos.max), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -228,14 +228,14 @@ namespace nil {
                 auto y_val = var_value(assignment, instance_input.y);
 
                 if (var_value(assignment, result.eq) == one) {
-                    assignment.witness(magic(var_pos.min)) = x_val;
-                    assignment.witness(magic(var_pos.max)) = x_val;
+                    assignment.witness(splat(var_pos.min)) = x_val;
+                    assignment.witness(splat(var_pos.max)) = x_val;
                 } else if (var_value(assignment, result.lt) == one) {
-                    assignment.witness(magic(var_pos.min)) = x_val;
-                    assignment.witness(magic(var_pos.max)) = y_val;
+                    assignment.witness(splat(var_pos.min)) = x_val;
+                    assignment.witness(splat(var_pos.max)) = y_val;
                 } else {
-                    assignment.witness(magic(var_pos.min)) = y_val;
-                    assignment.witness(magic(var_pos.max)) = x_val;
+                    assignment.witness(splat(var_pos.min)) = y_val;
+                    assignment.witness(splat(var_pos.max)) = x_val;
                 }
 
                 return typename plonk_fixedpoint_cmp_min_max<BlueprintFieldType, ArithmetizationParams>::result_type(
@@ -259,11 +259,11 @@ namespace nil {
                 auto cmp_comp = component.get_cmp_component();
                 auto constraints = get_constraints(cmp_comp, bp, assignment, instance_input);
 
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
-                auto min = var(magic(var_pos.min));
-                auto max = var(magic(var_pos.max));
-                auto s = var(magic(var_pos.s));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto min = var(splat(var_pos.min));
+                auto max = var(splat(var_pos.max));
+                auto s = var(splat(var_pos.s));
                 auto inv2 = typename BlueprintFieldType::value_type(2).inversed();
 
                 auto constraint_1 = min - inv2 * (s * (y - x) + x + y);

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp_min_max.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cmp_min_max.hpp
@@ -251,7 +251,7 @@ namespace nil {
                 const typename plonk_fixedpoint_cmp_min_max<BlueprintFieldType, ArithmetizationParams>::input_type
                     &instance_input) {
 
-                int64_t start_row_index = 1 - component.rows_amount;
+                int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
                 using var = typename plonk_fixedpoint_cmp_min_max<BlueprintFieldType, ArithmetizationParams>::var;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cos.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cos.hpp
@@ -529,9 +529,9 @@ namespace nil {
                 auto x0 = var(var_pos.x0.column() + m2 - 0, var_pos.x0.row());
                 auto x1 = var(var_pos.x0.column() + m2 - 1, var_pos.x0.row());
                 auto x2 = var(var_pos.x0.column() + m2 - 2, var_pos.x0.row());    // invalid if m2 == 1
-                auto sin0 = var(var_pos.sin0.column() + m2 - 0, var_pos.sin0.row());
-                auto sin1 = var(var_pos.sin0.column() + m2 - 1, var_pos.sin0.row());
-                auto sin2 = var(var_pos.sin0.column() + m2 - 2, var_pos.sin0.row());    // invalid if m2 == 1
+                auto sin0 = var(var_pos.sin0.column() + 0, var_pos.sin0.row());
+                auto sin1 = var(var_pos.sin0.column() + 1, var_pos.sin0.row());
+                auto sin2 = var(var_pos.sin0.column() + 2, var_pos.sin0.row());    // invalid if m2 == 1
                 {
                     constraint_type constraint;
                     constraint.table_id = sin_a_table_id;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cos.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cos.hpp
@@ -192,12 +192,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_cos &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     result_type(const fix_cos &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -253,16 +253,16 @@ namespace nil {
                 auto delta = value_type(component.get_delta());
 
                 auto x_val = var_value(assignment, instance_input.x);
-                assignment.witness(magic(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
                 std::vector<uint16_t> x0_val;
                 auto x_reduced_val = x_val;    // x_reduced guarantees the use of only one pre-comma limb
                 if (m1 == 2) {                 // if two pre-comma limbs are used, x is reduced mod 2*pi
-                    assignment.constant(magic(var_pos.two_pi)) = component.two_pi;
+                    assignment.constant(splat(var_pos.two_pi)) = component.two_pi;
                     auto rem_component = component.get_rem_component();
                     typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::rem_component::input_type
                         rem_input;
-                    rem_input.x = var(magic(var_pos.x));
-                    rem_input.y = var(magic(var_pos.two_pi), true, var::column_type::constant);
+                    rem_input.x = var(splat(var_pos.x));
+                    rem_input.y = var(splat(var_pos.two_pi), true, var::column_type::constant);
                     auto rem_result = generate_assignments(rem_component, assignment, rem_input, var_pos.rem_row);
                     x_reduced_val = var_value(assignment, rem_result.output);
                 }
@@ -292,13 +292,13 @@ namespace nil {
                 auto cos1_val = cos_b_table[x0_val[m2 - 1]];
                 auto cos2_val = delta;
 
-                assignment.witness(magic(var_pos.sin0)) = sin0_val;
+                assignment.witness(splat(var_pos.sin0)) = sin0_val;
                 assignment.witness(var_pos.sin0.column() + 1, var_pos.sin0.row()) = sin1_val;
                 if (m2 == 2) {
                     assignment.witness(var_pos.sin0.column() + 2, var_pos.sin0.row()) = sin2_val;
                 }
-                assignment.witness(magic(var_pos.cos0)) = cos0_val;
-                assignment.witness(magic(var_pos.cos1)) = cos1_val;
+                assignment.witness(splat(var_pos.cos0)) = cos0_val;
+                assignment.witness(splat(var_pos.cos1)) = cos1_val;
 
                 // cos(-a)    = cos(a)
                 // sin(a+b)   = sin(a)cos(b) + cos(a)sin(b)
@@ -315,10 +315,10 @@ namespace nil {
                 auto y_val = tmp.quotient;
                 auto q_val = tmp.remainder;
 
-                assignment.witness(magic(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
 
                 if (m2 == 1) {
-                    assignment.witness(magic(var_pos.q0)) = q_val;
+                    assignment.witness(splat(var_pos.q0)) = q_val;
                 } else {    // m2 == 2
                     std::vector<uint16_t> q0_val;
                     bool sign_ = FixedPointHelper<BlueprintFieldType>::decompose(q_val, q0_val);
@@ -350,8 +350,8 @@ namespace nil {
                 auto m = component.get_m();
 
                 auto delta = typename BlueprintFieldType::value_type(component.get_delta());
-                auto x = var(magic(var_pos.x));
-                auto x0 = nil::crypto3::math::expression(var(magic(var_pos.x0)));
+                auto x = var(splat(var_pos.x));
+                auto x0 = nil::crypto3::math::expression(var(splat(var_pos.x0)));
 
                 // decomposition of x
                 for (size_t i = 1; i < m2 + 1; i++) {
@@ -367,14 +367,14 @@ namespace nil {
                 // we don't care about the sign of x
                 auto constraint_1 = (x_reduced - x0) * (x_reduced + x0);
 
-                auto y = var(magic(var_pos.y));
-                auto sin0 = var(magic(var_pos.sin0));
+                auto y = var(splat(var_pos.y));
+                auto sin0 = var(splat(var_pos.sin0));
                 auto sin1 = var(var_pos.sin0.column() + 1, var_pos.sin0.row());
-                auto cos0 = var(magic(var_pos.cos0));
-                auto cos1 = var(magic(var_pos.cos1));
+                auto cos0 = var(splat(var_pos.cos0));
+                auto cos1 = var(splat(var_pos.cos1));
                 auto sin2 = var(var_pos.sin0.column() + 2, var_pos.sin0.row());
                 auto cos2 = delta;
-                auto q = nil::crypto3::math::expression(var(magic(var_pos.q0)));
+                auto q = nil::crypto3::math::expression(var(splat(var_pos.q0)));
                 for (size_t i = 1; i < m2 * m2; i++) {
                     q += var(var_pos.q0.column() + i, var_pos.q0.row()) * (1ULL << (16 * i));
                 }
@@ -413,7 +413,7 @@ namespace nil {
                 const std::size_t start_row_index) {
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
                 using var = typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::var;
-                var x = var(magic(var_pos.x), false);
+                var x = var(splat(var_pos.x), false);
                 bp.add_copy_constraint({instance_input.x, x});
             }
 
@@ -433,8 +433,8 @@ namespace nil {
 
                     using var = typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::var;
 
-                    rem_input.x = var(magic(var_pos.x), false);
-                    rem_input.y = var(magic(var_pos.two_pi), false, var::column_type::constant);
+                    rem_input.x = var(splat(var_pos.x), false);
+                    rem_input.y = var(splat(var_pos.two_pi), false, var::column_type::constant);
 
                     generate_circuit(component.get_rem_component(), bp, assignment, rem_input, var_pos.rem_row);
                 }

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cos.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cos.hpp
@@ -184,9 +184,12 @@ namespace nil {
                 constexpr static std::size_t get_rows_amount(std::size_t witness_amount,
                                                              std::size_t lookup_column_amount, uint8_t m1, uint8_t m2) {
                     if (M(m1) == 2 && M(m2) == 1) {
-                        return 1 + rem_component::get_rows_amount(get_witness_columns(m1, m2), 0, m1, 2);
+                        return 1 +
+                               rem_component::get_rows_amount(get_witness_columns(m1, m2), lookup_column_amount, m1, 2);
                     }
-                    return M(m1) == 2 ? 1 + rem_component::get_rows_amount(get_witness_columns(m1, m2), 0, m1, m2) : 1;
+                    return M(m1) == 2 ? 1 + rem_component::get_rows_amount(get_witness_columns(m1, m2),
+                                                                           lookup_column_amount, m1, m2) :
+                                        1;
                 }
 
                 constexpr static value_type get_two_pi() {

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cos.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cos.hpp
@@ -1,0 +1,457 @@
+#ifndef CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_COS_HPP
+#define CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_COS_HPP
+
+#include "nil/blueprint/components/algebra/fixedpoint/plonk/rem.hpp"
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+
+            // Works by decomposing x into up to three limbs and using the identities sin(a+b) = sin(a)cos(b) +
+            // cos(a)sin(b) and cos(a+b) = cos(a)cos(b) - sin(a)sin(b) multiple times, followed by one custom rescale
+            // operation. The evaluations of sin and cos are retrieved via pre-computed lookup tables. In case m1 >= 2,
+            // a rem operation (mod 2*pi) brings x into a range where one pre-comma limb is sufficient for computing
+            // cos(x).
+
+            /**
+             * Component representing a cos operation with input x and output y, where y = cos(x).
+             *
+             * The delta of y is the same as the delta of x.
+             *
+             * Input:  x ... field element
+             * Output: y ... cos(x) (field element)
+             */
+            template<typename ArithmetizationType, typename FieldType, typename NonNativePolicyType>
+            class fix_cos;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams, typename NonNativePolicyType>
+            class fix_cos<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                          BlueprintFieldType, NonNativePolicyType>
+                : public plonk_component<BlueprintFieldType, ArithmetizationParams, 1, 0> {
+
+            public:
+                using rem_component =
+                    fix_rem<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                            BlueprintFieldType, basic_non_native_policy<BlueprintFieldType>>;
+
+            private:
+                uint8_t m1;    // Pre-comma 16-bit limbs
+                uint8_t m2;    // Post-comma 16-bit limbs
+                rem_component rem;
+
+                static uint8_t M(uint8_t m) {
+                    if (m == 0 || m > 2) {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+                    return m;
+                }
+
+            public:
+                struct var_positions {
+                    CellPosition x, y, x0, q0, sin0, cos0, cos1, two_pi;
+                    typename rem_component::var_positions rem_pos;
+                    int64_t start_row, rem_row, sin_row;
+                };
+
+                var_positions get_var_pos(const int64_t start_row_index) const {
+
+                    // trace layout (6 + m2 * (2 + m2) col(s), 1 + rem_rows row(s))
+                    //              (9 if m2=1, 14 if m2=2 col(s))
+                    //
+                    // rem only exists if m1=2; rem_rows = 0 if m1=1
+                    // two_pi only exists if rem exists
+                    // t = 0 if m2 = 1
+                    // t = 3 if m2 = 2
+                    //
+                    //     |                                         witness                                         |
+                    //  r\c| 0 | 1 | 2  | .. | 2+m2|3+m2|..|3+m2+t| 4+m2+t| .. |4+2*m2+t | 5+2*m2+t | 6+2*m2+t |
+                    // +---+---+---+----+----+-----+----+--+------+-------+----+---------+----------+----------+
+                    // |rem| <rem_witness>                                                                     |
+                    // |sin| x | y | x0 | .. | xm2 | q0 |..|  qt  | sin0  | .. |  sinm2  |   cos0   |   cos1   |
+                    //
+                    //     | constant |
+                    //  r\c|    0     |
+                    // +---+----------+
+                    // |rem|  two_pi  |
+
+                    auto m1 = this->m1;
+                    auto m2 = this->m2;
+                    auto t = m2 * m2 - 1;
+                    var_positions pos;
+
+                    pos.start_row = start_row_index;
+                    pos.rem_row = pos.start_row;
+                    pos.sin_row = pos.rem_row;
+
+                    if (m1 == 2) {
+                        pos.sin_row += rem.rows_amount;
+                        pos.rem_pos = rem.get_var_pos(pos.rem_row);
+                        pos.two_pi = CellPosition(this->C(0), pos.rem_row);
+                    }
+
+                    pos.x = CellPosition(this->W(0), pos.sin_row);
+                    pos.y = CellPosition(this->W(1), pos.sin_row);
+                    pos.x0 = CellPosition(this->W(2 + 0 * (m2 + 1)), pos.sin_row);    // occupies m2 + 1 cells
+                    pos.q0 = CellPosition(this->W(2 + 1 * (m2 + 1)), pos.sin_row);    // occupies t+1 cells
+                    pos.sin0 = CellPosition(this->W(4 + m2 + t), pos.sin_row);        // occupies m2 + 1 cells
+                    pos.cos0 = CellPosition(this->W(5 + 2 * m2 + t), pos.sin_row);
+                    pos.cos1 = CellPosition(this->W(6 + 2 * m2 + t), pos.sin_row);
+                    return pos;
+                }
+
+            private:
+                rem_component instantiate_rem() const {
+                    auto m1 = this->m1;
+                    auto m2 = this->m2;
+                    std::vector<std::uint32_t> witness_list;
+                    auto witness_columns = rem_component::get_witness_columns(this->witness_amount(), m1, m2);
+                    BLUEPRINT_RELEASE_ASSERT(this->witness_amount() >= witness_columns);
+                    witness_list.reserve(witness_columns);
+                    for (auto i = 0; i < witness_columns; i++) {
+                        witness_list.push_back(this->W(i));
+                    }
+                    // if m1=1: a rem_component is constructed but never used.
+                    return rem_component(witness_list, std::array<std::uint32_t, 0>(), std::array<std::uint32_t, 0>(),
+                                         m1, m2);
+                }
+
+            public:
+                const rem_component &get_rem_component() const {
+                    return rem;
+                }
+
+                uint64_t get_delta() const {
+                    return 1ULL << (16 * this->m2);
+                }
+
+                uint8_t get_m2() const {
+                    BLUEPRINT_RELEASE_ASSERT(this->m2 == rem.get_m2());
+                    return this->m2;
+                }
+
+                uint8_t get_m1() const {
+                    return this->m1;
+                }
+
+                uint8_t get_m() const {
+                    return this->m1 + this->m2;
+                }
+
+                constexpr static std::size_t get_witness_columns(uint8_t m2) {
+                    return M(m2) == 1 ? 9 : 14;
+                }
+
+                using component_type = plonk_component<BlueprintFieldType, ArithmetizationParams, 1, 0>;
+
+                using var = typename component_type::var;
+                using value_type = typename BlueprintFieldType::value_type;
+                using manifest_type = plonk_component_manifest;
+
+                value_type two_pi;
+
+                class gate_manifest_type : public component_gate_manifest {
+                public:
+                    std::uint32_t gates_amount() const override {
+                        return fix_cos::gates_amount;
+                    }
+                };
+
+                static gate_manifest get_gate_manifest(std::size_t witness_amount, std::size_t lookup_column_amount) {
+                    static gate_manifest manifest = gate_manifest(gate_manifest_type());
+                    return manifest;
+                }
+
+                // TACEO_TODO Update to lookup tables
+                static manifest_type get_manifest(uint8_t m2) {
+                    static manifest_type manifest = manifest_type(
+                        std::shared_ptr<manifest_param>(new manifest_single_value_param(get_witness_columns(m2))),
+                        true);
+                    return manifest;
+                }
+
+                constexpr static std::size_t get_rows_amount(uint8_t m1, uint8_t m2) {
+                    return M(m1) == 2 ? 1 + rem_component::get_rows_amount(get_witness_columns(m2), 0, m1, m2) : 1;
+                }
+
+                constexpr static value_type get_two_pi(uint8_t m2) {
+                    return M(m2) == 1 ? value_type(411775ULL) : value_type(26986075409ULL);
+                }
+
+                constexpr static const std::size_t gates_amount = 2;
+                const std::size_t rows_amount = get_rows_amount(this->m1, this->m2);
+
+                struct input_type {
+                    var x = var(0, 0, false);
+
+                    std::vector<var> all_vars() const {
+                        return {x};
+                    }
+                };
+
+                struct result_type {
+                    var output = var(0, 0, false);
+                    result_type(const fix_cos &component, std::uint32_t start_row_index) {
+                        const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                        output = var(magic(var_pos.y), false);
+                    }
+
+                    result_type(const fix_cos &component, std::size_t start_row_index) {
+                        const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                        output = var(magic(var_pos.y), false);
+                    }
+
+                    std::vector<var> all_vars() const {
+                        return {output};
+                    }
+                };
+
+                template<typename ContainerType>
+                explicit fix_cos(ContainerType witness, uint8_t m1, uint8_t m2) :
+                    component_type(witness, {}, {}, get_manifest(m2)), m1(M(m1)), m2(M(m2)), rem(instantiate_rem()),
+                    two_pi(get_two_pi(m2)) {};
+
+                template<typename WitnessContainerType, typename ConstantContainerType,
+                         typename PublicInputContainerType>
+                fix_cos(WitnessContainerType witness, ConstantContainerType constant,
+                        PublicInputContainerType public_input, uint8_t m1, uint8_t m2) :
+                    component_type(witness, constant, public_input, get_manifest(m2)),
+                    m1(M(m1)), m2(M(m2)), rem(instantiate_rem()), two_pi(get_two_pi(m2)) {};
+
+                fix_cos(std::initializer_list<typename component_type::witness_container_type::value_type> witnesses,
+                        std::initializer_list<typename component_type::constant_container_type::value_type> constants,
+                        std::initializer_list<typename component_type::public_input_container_type::value_type>
+                            public_inputs,
+                        uint8_t m1, uint8_t m2) :
+                    component_type(witnesses, constants, public_inputs, get_manifest(m2)),
+                    m1(M(m1)), m2(M(m2)), rem(instantiate_rem()), two_pi(get_two_pi(m2)) {};
+            };
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            using plonk_fixedpoint_cos =
+                fix_cos<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                        BlueprintFieldType, basic_non_native_policy<BlueprintFieldType>>;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::result_type generate_assignments(
+                const plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams> &component,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::input_type
+                    instance_input,
+                const std::uint32_t start_row_index) {
+
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                using var = typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::var;
+                using value_type = typename BlueprintFieldType::value_type;
+
+                auto m1 = component.get_m1();
+                auto m2 = component.get_m2();
+                auto m = component.get_m();
+
+                auto one = value_type::one();
+                auto zero = value_type::zero();
+                auto delta = value_type(component.get_delta());
+
+                auto x_val = var_value(assignment, instance_input.x);
+                assignment.witness(magic(var_pos.x)) = x_val;
+                std::vector<uint16_t> x0_val;
+                auto x_reduced_val = x_val;    // x_reduced guarantees the use of only one pre-comma limb
+                if (m1 == 2) {                 // if two pre-comma limbs are used, x is reduced mod 2*pi
+                    assignment.constant(magic(var_pos.two_pi)) = component.two_pi;
+                    auto rem_component = component.get_rem_component();
+                    typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::rem_component::input_type
+                        rem_input;
+                    rem_input.x = var(magic(var_pos.x));
+                    rem_input.y = var(magic(var_pos.two_pi), true, var::column_type::constant);
+                    auto rem_result = generate_assignments(rem_component, assignment, rem_input, var_pos.rem_row);
+                    x_reduced_val = var_value(assignment, rem_result.output);
+                }
+                bool sign = FixedPointHelper<BlueprintFieldType>::decompose(x_reduced_val, x0_val);
+                if (m1 == 2) {
+                    BLUEPRINT_RELEASE_ASSERT(!sign);
+                }
+                BLUEPRINT_RELEASE_ASSERT(x0_val.size() >= (m2 + 1));
+                for (size_t i = 0; i < m2 + 1; i++) {
+                    assignment.witness(var_pos.x0.column() + i, var_pos.x0.row()) = x0_val[i];
+                }
+
+                auto sin_a_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_sin_a_16() :
+                                             FixedPointTables<BlueprintFieldType>::get_sin_a_32();
+                auto sin_b_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_sin_b_16() :
+                                             FixedPointTables<BlueprintFieldType>::get_sin_b_32();
+                auto cos_a_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_cos_a_16() :
+                                             FixedPointTables<BlueprintFieldType>::get_cos_a_32();
+                auto cos_b_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_cos_b_16() :
+                                             FixedPointTables<BlueprintFieldType>::get_cos_b_32();
+                auto sin_c_table = FixedPointTables<BlueprintFieldType>::get_sin_c_32();
+
+                auto sin0_val = sin_a_table[x0_val[m2 - 0]];
+                auto sin1_val = sin_b_table[x0_val[m2 - 1]];
+                auto sin2_val = m2 == 1 ? zero : sin_c_table[x0_val[m2 - 2]];
+                auto cos0_val = cos_a_table[x0_val[m2 - 0]];
+                auto cos1_val = cos_b_table[x0_val[m2 - 1]];
+                auto cos2_val = delta;
+
+                assignment.witness(magic(var_pos.sin0)) = sin0_val;
+                assignment.witness(var_pos.sin0.column() + 1, var_pos.sin0.row()) = sin1_val;
+                if (m2 == 2) {
+                    assignment.witness(var_pos.sin0.column() + 2, var_pos.sin0.row()) = sin2_val;
+                }
+                assignment.witness(magic(var_pos.cos0)) = cos0_val;
+                assignment.witness(magic(var_pos.cos1)) = cos1_val;
+
+                // cos(-a)    = cos(a)
+                // sin(a+b)   = sin(a)cos(b) + cos(a)sin(b)
+                // sin(a+b+c) = sin(a+b)cos(c) + cos(a+b)sin(c)
+                //            = cos(c) * (sin(a)cos(b) + cos(a)sin(b))
+                //            + sin(c) * (cos(a)cos(b) - sin(a)sin(b))
+                value_type computation = m2 == 1 ? (cos0_val * cos1_val - sin0_val * sin1_val) :
+                                                   (cos2_val * (cos0_val * cos1_val - sin0_val * sin1_val) -
+                                                    sin2_val * (sin0_val * cos1_val + cos0_val * sin1_val));
+
+                auto actual_delta = m2 == 1 ? delta : delta * delta;
+
+                auto tmp = FixedPointHelper<BlueprintFieldType>::round_div_mod(computation, actual_delta);
+                auto y_val = tmp.quotient;
+                auto q_val = tmp.remainder;
+
+                assignment.witness(magic(var_pos.y)) = y_val;
+
+                if (m2 == 1) {
+                    assignment.witness(magic(var_pos.q0)) = q_val;
+                } else {    // m2 == 2
+                    std::vector<uint16_t> q0_val;
+                    bool sign_ = FixedPointHelper<BlueprintFieldType>::decompose(q_val, q0_val);
+                    BLUEPRINT_RELEASE_ASSERT(!sign_);
+                    BLUEPRINT_RELEASE_ASSERT(q0_val.size() >= (4));
+                    for (size_t i = 0; i < 4; i++) {
+                        assignment.witness(var_pos.q0.column() + i, var_pos.q0.row()) = q0_val[i];
+                    }
+                }
+
+                return typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::vector<crypto3::zk::snark::plonk_constraint<BlueprintFieldType>> get_constraints(
+                const plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+
+                using var = typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::var;
+                auto m1 = component.get_m1();
+                auto m2 = component.get_m2();
+                auto m = component.get_m();
+
+                auto delta = typename BlueprintFieldType::value_type(component.get_delta());
+                auto x = var(magic(var_pos.x));
+                auto x0 = nil::crypto3::math::expression(var(magic(var_pos.x0)));
+
+                // decomposition of x
+                for (size_t i = 1; i < m2 + 1; i++) {
+                    x0 += var(var_pos.x0.column() + i, var_pos.x0.row()) * (1ULL << (16 * i));
+                }
+                auto x_reduced = x;
+                if (m1 == 2) {
+                    typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::rem_component::result_type
+                        rem_out(component.get_rem_component(), static_cast<uint32_t>(var_pos.rem_row));
+                    x_reduced = var(rem_out.output);
+                }
+
+                // we don't care about the sign of x
+                auto constraint_1 = (x_reduced - x0) * (x_reduced + x0);
+
+                auto y = var(magic(var_pos.y));
+                auto sin0 = var(magic(var_pos.sin0));
+                auto sin1 = var(var_pos.sin0.column() + 1, var_pos.sin0.row());
+                auto cos0 = var(magic(var_pos.cos0));
+                auto cos1 = var(magic(var_pos.cos1));
+                auto sin2 = var(var_pos.sin0.column() + 2, var_pos.sin0.row());
+                auto cos2 = delta;
+                auto q = nil::crypto3::math::expression(var(magic(var_pos.q0)));
+                for (size_t i = 1; i < m2 * m2; i++) {
+                    q += var(var_pos.q0.column() + i, var_pos.q0.row()) * (1ULL << (16 * i));
+                }
+
+                auto computation = m2 == 1 ? (cos0 * cos1 - sin0 * sin1) :
+                                             (cos2 * (cos0 * cos1 - sin0 * sin1) - sin2 * (sin0 * cos1 + cos0 * sin1));
+                auto actual_delta = m2 == 1 ? delta : delta * delta;
+
+                auto constraint_2 = 2 * (computation - y * actual_delta - q) + actual_delta;    // "custom" rescale
+
+                // TACEO_TODO extend for lookup constraint for x0, q0, sin0, cos0
+                return {constraint_1, constraint_2};
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_gates(
+                const plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+
+                auto constraints = get_constraints(component, bp, assignment, instance_input);
+                return bp.add_gate(constraints);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            void generate_copy_constraints(
+                const plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input,
+                const std::size_t start_row_index) {
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                using var = typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::var;
+                var x = var(magic(var_pos.x), false);
+                bp.add_copy_constraint({instance_input.x, x});
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::result_type generate_circuit(
+                const plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input,
+                const std::size_t start_row_index) {
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                if (component.get_m1() == 2) {    // if m1=2, rem exists
+                    typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::rem_component::input_type
+                        rem_input;
+
+                    using var = typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::var;
+
+                    rem_input.x = var(magic(var_pos.x), false);
+                    rem_input.y = var(magic(var_pos.two_pi), false, var::column_type::constant);
+
+                    generate_circuit(component.get_rem_component(), bp, assignment, rem_input, var_pos.rem_row);
+                }
+
+                // TACEO_TODO extend for lookup?
+                std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
+
+                assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
+
+                generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
+
+                return typename plonk_fixedpoint_cos<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_COS_HPP

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cos.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cos.hpp
@@ -526,12 +526,12 @@ namespace nil {
                 }
 
                 // lookup sin, cos
-                auto x0 = var(var_pos.x0.column() + 0, var_pos.x0.row());
-                auto x1 = var(var_pos.x0.column() + 1, var_pos.x0.row());
-                auto x2 = var(var_pos.x0.column() + 2, var_pos.x0.row());
-                auto sin0 = var(var_pos.sin0.column() + 0, var_pos.sin0.row());
-                auto sin1 = var(var_pos.sin0.column() + 1, var_pos.sin0.row());
-                auto sin2 = var(var_pos.sin0.column() + 2, var_pos.sin0.row());
+                auto x0 = var(var_pos.x0.column() + m2 - 0, var_pos.x0.row());
+                auto x1 = var(var_pos.x0.column() + m2 - 1, var_pos.x0.row());
+                auto x2 = var(var_pos.x0.column() + m2 - 2, var_pos.x0.row());    // invalid if m2 == 1
+                auto sin0 = var(var_pos.sin0.column() + m2 - 0, var_pos.sin0.row());
+                auto sin1 = var(var_pos.sin0.column() + m2 - 1, var_pos.sin0.row());
+                auto sin2 = var(var_pos.sin0.column() + m2 - 2, var_pos.sin0.row());    // invalid if m2 == 1
                 {
                     constraint_type constraint;
                     constraint.table_id = sin_a_table_id;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cos.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cos.hpp
@@ -165,7 +165,6 @@ namespace nil {
                     return manifest;
                 }
 
-                // TACEO_TODO Update to lookup tables
                 static manifest_type get_manifest(uint8_t m2) {
                     static manifest_type manifest = manifest_type(
                         std::shared_ptr<manifest_param>(new manifest_single_value_param(get_witness_columns(m2))),
@@ -173,7 +172,8 @@ namespace nil {
                     return manifest;
                 }
 
-                constexpr static std::size_t get_rows_amount(uint8_t m1, uint8_t m2) {
+                constexpr static std::size_t get_rows_amount(std::size_t witness_amount,
+                                                             std::size_t lookup_column_amount, uint8_t m1, uint8_t m2) {
                     return M(m1) == 2 ? 1 + rem_component::get_rows_amount(get_witness_columns(m2), 0, m1, m2) : 1;
                 }
 
@@ -182,7 +182,7 @@ namespace nil {
                 }
 
                 constexpr static const std::size_t gates_amount = 2;
-                const std::size_t rows_amount = get_rows_amount(this->m1, this->m2);
+                const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, this->m1, this->m2);
 
                 struct input_type {
                     var x = var(0, 0, false);
@@ -445,7 +445,6 @@ namespace nil {
 
                 auto constraint_2 = 2 * (computation - y * actual_delta - q) + actual_delta;    // "custom" rescale
 
-                // TACEO_TODO extend for lookup constraint for x0, q0, sin0, cos0
                 return {constraint_1, constraint_2};
             }
 
@@ -599,7 +598,6 @@ namespace nil {
                     generate_circuit(component.get_rem_component(), bp, assignment, rem_input, var_pos.rem_row);
                 }
 
-                // TACEO_TODO extend for lookup?
                 std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
 
                 assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cos.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cos.hpp
@@ -51,7 +51,7 @@ namespace nil {
                 struct var_positions {
                     CellPosition x, y, x0, q0, sin0, cos0, cos1, two_pi;
                     typename rem_component::var_positions rem_pos;
-                    int64_t start_row, rem_row, sin_row;
+                    int64_t start_row, rem_row, cos_row;
                 };
 
                 var_positions get_var_pos(const int64_t start_row_index) const {
@@ -68,7 +68,7 @@ namespace nil {
                     //  r\c| 0 | 1 | 2  | .. | 2+m2|3+m2|..|3+m2+t| 4+m2+t| .. |4+2*m2+t | 5+2*m2+t | 6+2*m2+t |
                     // +---+---+---+----+----+-----+----+--+------+-------+----+---------+----------+----------+
                     // |rem| <rem_witness>                                                                     |
-                    // |sin| x | y | x0 | .. | xm2 | q0 |..|  qt  | sin0  | .. |  sinm2  |   cos0   |   cos1   |
+                    // |cos| x | y | x0 | .. | xm2 | q0 |..|  qt  | sin0  | .. |  sinm2  |   cos0   |   cos1   |
                     //
                     //     | constant |
                     //  r\c|    0     |
@@ -82,21 +82,21 @@ namespace nil {
 
                     pos.start_row = start_row_index;
                     pos.rem_row = pos.start_row;
-                    pos.sin_row = pos.rem_row;
+                    pos.cos_row = pos.rem_row;
 
                     if (m1 == 2) {
-                        pos.sin_row += rem.rows_amount;
+                        pos.cos_row += rem.rows_amount;
                         pos.rem_pos = rem.get_var_pos(pos.rem_row);
                         pos.two_pi = CellPosition(this->C(0), pos.rem_row);
                     }
 
-                    pos.x = CellPosition(this->W(0), pos.sin_row);
-                    pos.y = CellPosition(this->W(1), pos.sin_row);
-                    pos.x0 = CellPosition(this->W(2 + 0 * (m2 + 1)), pos.sin_row);    // occupies m2 + 1 cells
-                    pos.q0 = CellPosition(this->W(2 + 1 * (m2 + 1)), pos.sin_row);    // occupies t+1 cells
-                    pos.sin0 = CellPosition(this->W(4 + m2 + t), pos.sin_row);        // occupies m2 + 1 cells
-                    pos.cos0 = CellPosition(this->W(5 + 2 * m2 + t), pos.sin_row);
-                    pos.cos1 = CellPosition(this->W(6 + 2 * m2 + t), pos.sin_row);
+                    pos.x = CellPosition(this->W(0), pos.cos_row);
+                    pos.y = CellPosition(this->W(1), pos.cos_row);
+                    pos.x0 = CellPosition(this->W(2 + 0 * (m2 + 1)), pos.cos_row);    // occupies m2 + 1 cells
+                    pos.q0 = CellPosition(this->W(2 + 1 * (m2 + 1)), pos.cos_row);    // occupies t+1 cells
+                    pos.sin0 = CellPosition(this->W(4 + m2 + t), pos.cos_row);        // occupies m2 + 1 cells
+                    pos.cos0 = CellPosition(this->W(5 + 2 * m2 + t), pos.cos_row);
+                    pos.cos1 = CellPosition(this->W(6 + 2 * m2 + t), pos.cos_row);
                     return pos;
                 }
 
@@ -513,6 +513,7 @@ namespace nil {
                 std::vector<constraint_type> constraints;
 
                 // lookup decomposition of x
+                // TODO not required, as this is covered by the sin/cos lookup tables
                 for (size_t i = 0; i < m2 + 1; i++) {
                     constraint_type constraint;
                     constraint.table_id = range_table_id;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/div.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/div.hpp
@@ -82,6 +82,9 @@ namespace nil {
 
                 using var = typename component_type::var;
                 using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using range_table = fixedpoint_range_table<BlueprintFieldType>;
 
                 class gate_manifest_type : public component_gate_manifest {
                 public:
@@ -95,11 +98,10 @@ namespace nil {
                     return manifest;
                 }
 
-                // TACEO_TODO Update to lookup tables
                 static manifest_type get_manifest(uint8_t m1, uint8_t m2) {
                     static manifest_type manifest =
-                        manifest_type(std::shared_ptr<manifest_param>(new manifest_range_param(
-                                          5 + (M(m2) + M(m1)), 5 + 3 * (m2 + m1))),
+                        manifest_type(std::shared_ptr<manifest_param>(
+                                          new manifest_range_param(5 + (M(m2) + M(m1)), 5 + 3 * (m2 + m1))),
                                       false);
                     return manifest;
                 }
@@ -113,7 +115,8 @@ namespace nil {
                     }
                 }
 
-                constexpr static const std::size_t gates_amount = 1;
+                // Includes the constraints + lookup_gates
+                constexpr static const std::size_t gates_amount = 2;
                 const std::size_t rows_amount =
                     get_rows_amount(this->witness_amount(), 0, div_by_pos.get_m1(), div_by_pos.get_m2());
 
@@ -171,6 +174,22 @@ namespace nil {
                     }
                     return pos;
                 }
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result = {};
+                    auto table = std::shared_ptr<lookup_table_definition>(new range_table());
+                    result.push_back(table);
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    return lookup_tables;
+                }
+#endif
 
                 template<typename ContainerType>
                 explicit fix_div(ContainerType witness, uint8_t m1, uint8_t m2) :
@@ -266,8 +285,52 @@ namespace nil {
                 auto constraint_4 = y - s_y * y_abs;
                 auto constraint_5 = (s_y - 1) * (s_y + 1);
 
-                // TACEO_TODO extend for lookup constraint
                 return bp.add_gate({constraint_1, constraint_2, constraint_3, constraint_4, constraint_5});
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_fixedpoint_div<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_div<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                int64_t start_row_index = 1 - component.rows_amount;
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m = component.get_m();
+
+                const std::map<std::string, std::size_t> &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_fixedpoint_div<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+                using range_table =
+                    typename plonk_fixedpoint_div<BlueprintFieldType, ArithmetizationParams>::range_table;
+
+                std::vector<constraint_type> constraints;
+                constraints.reserve(3 * m);
+
+                auto table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
+
+                for (auto i = 0; i < m; i++) {
+                    constraint_type constraint_q, constraint_a, constraint_y;
+                    constraint_q.table_id = table_id;
+                    constraint_a.table_id = table_id;
+                    constraint_y.table_id = table_id;
+
+                    // We put row=0 here and enable the selector in the correct one
+                    auto qi = var(var_pos.q0.column() + i, var_pos.q0.row());
+                    auto ai = var(var_pos.a0.column() + i, var_pos.a0.row());
+                    auto yi = var(var_pos.y0.column() + i, var_pos.y0.row());
+                    constraint_q.lookup_input = {qi};
+                    constraint_a.lookup_input = {ai};
+                    constraint_y.lookup_input = {yi};
+                    constraints.push_back(constraint_q);
+                    constraints.push_back(constraint_a);
+                    constraints.push_back(constraint_y);
+                }
+
+                return bp.add_lookup_gate(constraints);
             }
 
             template<typename BlueprintFieldType, typename ArithmetizationParams>
@@ -280,11 +343,18 @@ namespace nil {
                     &instance_input,
                 const std::size_t start_row_index) {
 
-                // TACEO_TODO extend for lookup?
+                auto last_row = start_row_index + component.rows_amount - 1;
+
                 std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
 
                 // selector goes onto last row and gate uses all rows
-                assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
+                assignment.enable_selector(selector_index, last_row);
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, last_row);
+#endif
 
                 // Enable the copy constraints of div_by_pos
                 auto div_by_pos_comp = component.get_div_by_pos_component();

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/div.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/div.hpp
@@ -237,7 +237,7 @@ namespace nil {
                 std::vector<uint16_t> y0_val;
 
                 bool sign = FixedPointHelper<BlueprintFieldType>::decompose(y_val, y0_val);
-                assignment.witness(magic(var_pos.s_y)) = sign ? -one : one;
+                assignment.witness(splat(var_pos.s_y)) = sign ? -one : one;
                 // is ok because decomp is at least of size 4 and the biggest we have is 32.32
                 BLUEPRINT_RELEASE_ASSERT(y0_val.size() >= m);
 
@@ -264,20 +264,20 @@ namespace nil {
                 auto m = component.get_m();
                 auto delta = component.get_delta();
 
-                auto y_abs = nil::crypto3::math::expression(var(magic(var_pos.y0)));
-                auto q = nil::crypto3::math::expression(var(magic(var_pos.q0)));
-                auto a = nil::crypto3::math::expression(var(magic(var_pos.a0)));
+                auto y_abs = nil::crypto3::math::expression(var(splat(var_pos.y0)));
+                auto q = nil::crypto3::math::expression(var(splat(var_pos.q0)));
+                auto a = nil::crypto3::math::expression(var(splat(var_pos.a0)));
 
                 for (auto i = 1; i < m; i++) {
                     y_abs += var(var_pos.y0.column() + i, var_pos.y0.row()) * (1ULL << (16 * i));
                     q += var(var_pos.q0.column() + i, var_pos.q0.row()) * (1ULL << (16 * i));
                     a += var(var_pos.a0.column() + i, var_pos.a0.row()) * (1ULL << (16 * i));
                 }
-                auto s_y = var(magic(var_pos.s_y));
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
-                auto z = var(magic(var_pos.z));
-                auto c = var(magic(var_pos.c));
+                auto s_y = var(splat(var_pos.s_y));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto z = var(splat(var_pos.z));
+                auto c = var(splat(var_pos.c));
 
                 auto constraint_1 = 2 * (x * delta - y * z - q) + y_abs - c;
                 auto constraint_2 = (c - 1) * c;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/div.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/div.hpp
@@ -78,6 +78,13 @@ namespace nil {
                     return div_by_pos.get_delta();
                 }
 
+                constexpr static std::size_t get_witness_columns(std::size_t witness_amount,
+                                                                 std::size_t lookup_column_amount, uint8_t m1,
+                                                                 uint8_t m2) {
+                    return get_rows_amount(witness_amount, lookup_column_amount, m1, m2) == 1 ? 5 + 3 * (m1 + m2) :
+                                                                                                4 + (m1 + m2);
+                }
+
                 using component_type = plonk_component<BlueprintFieldType, ArithmetizationParams, 0, 0>;
 
                 using var = typename component_type::var;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/div.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/div.hpp
@@ -256,7 +256,7 @@ namespace nil {
                     &assignment,
                 const typename plonk_fixedpoint_div<BlueprintFieldType, ArithmetizationParams>::input_type
                     &instance_input) {
-                int64_t start_row_index = 1 - component.rows_amount;
+                int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
                 using var = typename plonk_fixedpoint_div<BlueprintFieldType, ArithmetizationParams>::var;
@@ -296,7 +296,7 @@ namespace nil {
                     &assignment,
                 const typename plonk_fixedpoint_div<BlueprintFieldType, ArithmetizationParams>::input_type
                     &instance_input) {
-                int64_t start_row_index = 1 - component.rows_amount;
+                int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(start_row_index);
                 auto m = component.get_m();
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/div.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/div.hpp
@@ -318,7 +318,6 @@ namespace nil {
                     constraint_a.table_id = table_id;
                     constraint_y.table_id = table_id;
 
-                    // We put row=0 here and enable the selector in the correct one
                     auto qi = var(var_pos.q0.column() + i, var_pos.q0.row());
                     auto ai = var(var_pos.a0.column() + i, var_pos.a0.row());
                     auto yi = var(var_pos.y0.column() + i, var_pos.y0.row());

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/div_by_positive.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/div_by_positive.hpp
@@ -320,7 +320,7 @@ namespace nil {
                     &assignment,
                 const typename plonk_fixedpoint_div_by_pos<BlueprintFieldType, ArithmetizationParams>::input_type
                     &instance_input) {
-                int64_t start_row_index = 0;
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(start_row_index);
                 auto m = component.get_m();
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/div_by_positive.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/div_by_positive.hpp
@@ -285,7 +285,7 @@ namespace nil {
                 const typename plonk_fixedpoint_div_by_pos<BlueprintFieldType, ArithmetizationParams>::input_type
                     &instance_input) {
 
-                int64_t start_row_index = 1 - component.rows_amount;
+                int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
                 using var = typename plonk_fixedpoint_div_by_pos<BlueprintFieldType, ArithmetizationParams>::var;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/div_by_positive.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/div_by_positive.hpp
@@ -10,6 +10,7 @@
 #include <nil/blueprint/basic_non_native_policy.hpp>
 
 #include "nil/blueprint/components/algebra/fixedpoint/type.hpp"
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp"
 
 namespace nil {
     namespace blueprint {
@@ -73,6 +74,9 @@ namespace nil {
 
                 using var = typename component_type::var;
                 using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using range_table = fixedpoint_range_table<BlueprintFieldType>;
 
                 class gate_manifest_type : public component_gate_manifest {
                 public:
@@ -86,7 +90,6 @@ namespace nil {
                     return manifest;
                 }
 
-                // TACEO_TODO Update to lookup tables
                 static manifest_type get_manifest(uint8_t m1, uint8_t m2) {
                     static manifest_type manifest =
                         manifest_type(std::shared_ptr<manifest_param>(
@@ -104,7 +107,8 @@ namespace nil {
                     }
                 }
 
-                constexpr static const std::size_t gates_amount = 1;
+                // Includes the constraints + lookup_gates
+                constexpr static const std::size_t gates_amount = 2;
                 const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, m1, m2);
 
                 struct input_type {
@@ -180,6 +184,22 @@ namespace nil {
                         return {output};
                     }
                 };
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result = {};
+                    auto table = std::shared_ptr<lookup_table_definition>(new range_table());
+                    result.push_back(table);
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    return lookup_tables;
+                }
+#endif
 
                 template<typename ContainerType>
                 explicit fix_div_by_pos(ContainerType witness, uint8_t m1, uint8_t m2) :
@@ -289,8 +309,49 @@ namespace nil {
                 auto constraint_2 = (c - 1) * c;
                 auto constraint_3 = y - q - a - 1;
 
-                // TACEO_TODO extend for lookup constraint
                 return bp.add_gate({constraint_1, constraint_2, constraint_3});
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_fixedpoint_div_by_pos<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_div_by_pos<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                int64_t start_row_index = 0;
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m = component.get_m();
+
+                const std::map<std::string, std::size_t> &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_fixedpoint_div_by_pos<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+                using range_table =
+                    typename plonk_fixedpoint_div_by_pos<BlueprintFieldType, ArithmetizationParams>::range_table;
+
+                std::vector<constraint_type> constraints;
+                constraints.reserve(2 * m);
+
+                auto table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
+                BLUEPRINT_RELEASE_ASSERT(var_pos.q0.row() == var_pos.a0.row());
+
+                for (auto i = 0; i < m; i++) {
+                    constraint_type constraint_q, constraint_a;
+                    constraint_q.table_id = table_id;
+                    constraint_a.table_id = table_id;
+
+                    // We put row=0 here and enable the selector in the correct one
+                    auto qi = var(var_pos.q0.column() + i, 0);
+                    auto ai = var(var_pos.a0.column() + i, 0);
+                    constraint_q.lookup_input = {qi};
+                    constraint_a.lookup_input = {ai};
+                    constraints.push_back(constraint_q);
+                    constraints.push_back(constraint_a);
+                }
+
+                return bp.add_lookup_gate(constraints);
             }
 
             template<typename BlueprintFieldType, typename ArithmetizationParams>
@@ -324,11 +385,17 @@ namespace nil {
                         &instance_input,
                     const std::size_t start_row_index) {
 
-                // TACEO_TODO extend for lookup?
                 std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
 
                 // selector goes onto last row and gate uses all rows
                 assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, var_pos.a0.row());    // same as q0.row()
+#endif
 
                 generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/div_by_positive.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/div_by_positive.hpp
@@ -172,12 +172,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_div_by_pos &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.z), false);
+                        output = var(splat(var_pos.z), false);
                     }
 
                     result_type(const fix_div_by_pos &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.z), false);
+                        output = var(splat(var_pos.z), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -248,9 +248,9 @@ namespace nil {
                     FixedPointHelper<BlueprintFieldType>::round_div_mod(tmp_mul, y_val);
                 auto z_val = tmp_div.quotient;
 
-                assignment.witness(magic(var_pos.x)) = x_val;
-                assignment.witness(magic(var_pos.y)) = y_val;
-                assignment.witness(magic(var_pos.z)) = z_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.z)) = z_val;
 
                 std::vector<uint16_t> q0_val;
                 std::vector<uint16_t> a0_val;
@@ -265,7 +265,7 @@ namespace nil {
                 BLUEPRINT_RELEASE_ASSERT(a0_val.size() >= m);
 
                 auto y_ = FixedPointHelper<BlueprintFieldType>::field_to_backend(y_val);
-                assignment.witness(magic(var_pos.c)) = typename BlueprintFieldType::value_type(y_.limbs()[0] & 1);
+                assignment.witness(splat(var_pos.c)) = typename BlueprintFieldType::value_type(y_.limbs()[0] & 1);
 
                 for (auto i = 0; i < m; i++) {
                     assignment.witness(var_pos.q0.column() + i, var_pos.q0.row()) = q0_val[i];
@@ -293,17 +293,17 @@ namespace nil {
                 auto m = component.get_m();
                 auto delta = component.get_delta();
 
-                auto q = nil::crypto3::math::expression(var(magic(var_pos.q0)));
-                auto a = nil::crypto3::math::expression(var(magic(var_pos.a0)));
+                auto q = nil::crypto3::math::expression(var(splat(var_pos.q0)));
+                auto a = nil::crypto3::math::expression(var(splat(var_pos.a0)));
                 for (auto i = 1; i < m; i++) {
                     q += var(var_pos.q0.column() + i, var_pos.q0.row()) * (1ULL << (16 * i));
                     a += var(var_pos.a0.column() + i, var_pos.a0.row()) * (1ULL << (16 * i));
                 }
 
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
-                auto z = var(magic(var_pos.z));
-                auto c = var(magic(var_pos.c));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto z = var(splat(var_pos.z));
+                auto c = var(splat(var_pos.c));
 
                 auto constraint_1 = 2 * (x * delta - y * z - q) + y - c;
                 auto constraint_2 = (c - 1) * c;
@@ -368,8 +368,8 @@ namespace nil {
 
                 using var = typename plonk_fixedpoint_div_by_pos<BlueprintFieldType, ArithmetizationParams>::var;
 
-                var x = var(magic(var_pos.x), false);
-                var y = var(magic(var_pos.y), false);
+                var x = var(splat(var_pos.x), false);
+                var y = var(splat(var_pos.y), false);
                 bp.add_copy_constraint({instance_input.x, x});
                 bp.add_copy_constraint({instance_input.y, y});
             }

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_1_gate.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_1_gate.hpp
@@ -299,7 +299,7 @@ namespace nil {
                     typename plonk_fixedpoint_dot_rescale_1_gate<BlueprintFieldType, ArithmetizationParams>::var;
                 typename plonk_fixedpoint_dot_rescale_1_gate<
                     BlueprintFieldType, ArithmetizationParams>::rescale_component::input_type rescale_input;
-                rescale_input.x = var(magic(var_pos.dot_result), false);
+                rescale_input.x = var(splat(var_pos.dot_result), false);
 
                 auto rescale_comp = component.get_rescale_component();
                 return generate_assignments(rescale_comp, assignment, rescale_input, var_pos.rescale_row);
@@ -328,8 +328,8 @@ namespace nil {
                     dot += var(component.W(x_pos.second), x_pos.first) * var(component.W(y_pos.second), y_pos.first);
                 }
 
-                auto dot_p = var(magic(var_pos.dot_p_0));
-                auto dot_c = var(magic(var_pos.dot_c_0));
+                auto dot_p = var(splat(var_pos.dot_p_0));
+                auto dot_c = var(splat(var_pos.dot_c_0));
                 auto constraint_1 = dot + dot_p - dot_c;
 
                 return bp.add_gate(constraint_1);
@@ -355,7 +355,7 @@ namespace nil {
                 auto dots_per_row = component.get_dots_per_row();
 
                 // constraint first previous dot to zero
-                bp.add_copy_constraint({instance_input.zero, var(magic(var_pos.dot_p_0), false)});
+                bp.add_copy_constraint({instance_input.zero, var(splat(var_pos.dot_p_0), false)});
 
                 for (auto i = 0; i < dots; i++) {
                     var x_i = get_copy_var(component, start_row_index, i, true);
@@ -407,7 +407,7 @@ namespace nil {
                     typename plonk_fixedpoint_dot_rescale_1_gate<BlueprintFieldType, ArithmetizationParams>::var;
                 typename plonk_fixedpoint_dot_rescale_1_gate<
                     BlueprintFieldType, ArithmetizationParams>::rescale_component::input_type rescale_input;
-                rescale_input.x = var(magic(var_pos.dot_result), false);
+                rescale_input.x = var(splat(var_pos.dot_result), false);
 
                 auto rescale_comp = component.get_rescale_component();
                 return generate_circuit(rescale_comp, bp, assignment, rescale_input, var_pos.rescale_row);

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_1_gate.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_1_gate.hpp
@@ -92,6 +92,8 @@ namespace nil {
 
                 using var = typename component_type::var;
                 using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
 
                 class gate_manifest_type : public component_gate_manifest {
                 private:

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_1_gate.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_1_gate.hpp
@@ -199,6 +199,17 @@ namespace nil {
 
                 using result_type = typename rescale_component::result_type;
 
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    return rescale.component_custom_lookup_tables();
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    return rescale.component_lookup_tables();
+                }
+#endif
+
                 template<typename ContainerType>
                 explicit fix_dot_rescale_1_gate(ContainerType witness, uint32_t dots, uint8_t m2) :
                     component_type(witness, {}, {}, get_manifest(dots, m2)), dots(dots),

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_1_gate.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_1_gate.hpp
@@ -105,7 +105,7 @@ namespace nil {
                     }
 
                     std::uint32_t gates_amount() const override {
-                        return fix_dot_rescale_1_gate::gates_amount;
+                        return fix_dot_rescale_1_gate::gates_amount + 1;
                     }
                 };
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_1_gate.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_1_gate.hpp
@@ -18,8 +18,8 @@ namespace nil {
              * Uses one gate (and one selector column) for the constraints and two columns for the (intermediate) sums
              * of the dot product.
              *
-             * Input:    x    ... field element
-             *           y    ... field element
+             * Input:    x    ... vector of field elements
+             *           y    ... vector of field elements
              *
              * Output:   z    ... x dot y (field element)
              *

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_1_gate.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_1_gate.hpp
@@ -105,7 +105,7 @@ namespace nil {
                     }
 
                     std::uint32_t gates_amount() const override {
-                        return rescale_component::gates_amount + 1;
+                        return fix_dot_rescale_1_gate::gates_amount;
                     }
                 };
 
@@ -137,6 +137,7 @@ namespace nil {
                     return rows;
                 }
 
+                constexpr static const std::size_t gates_amount = rescale_component::gates_amount + 1;
                 const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, dots, rescale.get_m2());
 
                 struct input_type {

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_2_gates.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_2_gates.hpp
@@ -92,6 +92,8 @@ namespace nil {
 
                 using var = typename component_type::var;
                 using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
 
                 class gate_manifest_type : public component_gate_manifest {
                 private:

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_2_gates.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_2_gates.hpp
@@ -18,8 +18,8 @@ namespace nil {
              * Uses two gates (and two selector columns) for the constraints and one column for the (intermediate) sums
              * of the dot product.
              *
-             * Input:    x    ... field element
-             *           y    ... field element
+             * Input:    x    ... vector of field elements
+             *           y    ... vector of field elements
              *
              * Output:   z    ... x dot y (field element)
              *

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_2_gates.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_2_gates.hpp
@@ -294,7 +294,7 @@ namespace nil {
                     typename plonk_fixedpoint_dot_rescale_2_gates<BlueprintFieldType, ArithmetizationParams>::var;
                 typename plonk_fixedpoint_dot_rescale_2_gates<
                     BlueprintFieldType, ArithmetizationParams>::rescale_component::input_type rescale_input;
-                rescale_input.x = var(magic(var_pos.dot_result), false);
+                rescale_input.x = var(splat(var_pos.dot_result), false);
 
                 auto rescale_comp = component.get_rescale_component();
                 return generate_assignments(rescale_comp, assignment, rescale_input, var_pos.rescale_row);
@@ -323,7 +323,7 @@ namespace nil {
                     dot += var(component.W(x_pos.second), x_pos.first) * var(component.W(y_pos.second), y_pos.first);
                 }
 
-                auto constraint_1 = dot - var(magic(var_pos.dot_0));
+                auto constraint_1 = dot - var(splat(var_pos.dot_0));
 
                 return bp.add_gate(constraint_1);
             }
@@ -352,7 +352,7 @@ namespace nil {
                 }
 
                 auto dot_p = var(var_pos.dot_0.column(), var_pos.dot_0.row() - 1);
-                auto dot_c = var(magic(var_pos.dot_0));
+                auto dot_c = var(splat(var_pos.dot_0));
                 auto constraint_1 = dot + dot_p - dot_c;
 
                 return bp.add_gate(constraint_1);
@@ -426,7 +426,7 @@ namespace nil {
                     typename plonk_fixedpoint_dot_rescale_2_gates<BlueprintFieldType, ArithmetizationParams>::var;
                 typename plonk_fixedpoint_dot_rescale_2_gates<
                     BlueprintFieldType, ArithmetizationParams>::rescale_component::input_type rescale_input;
-                rescale_input.x = var(magic(var_pos.dot_result), false);
+                rescale_input.x = var(splat(var_pos.dot_result), false);
 
                 auto rescale_comp = component.get_rescale_component();
                 return generate_circuit(rescale_comp, bp, assignment, rescale_input, var_pos.rescale_row);

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_2_gates.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_2_gates.hpp
@@ -105,7 +105,7 @@ namespace nil {
                     }
 
                     std::uint32_t gates_amount() const override {
-                        return fix_dot_rescale_2_gates::gates_amount;
+                        return fix_dot_rescale_2_gates::gates_amount + 2;
                     }
                 };
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_2_gates.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_2_gates.hpp
@@ -195,6 +195,17 @@ namespace nil {
 
                 using result_type = typename rescale_component::result_type;
 
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    return rescale.component_custom_lookup_tables();
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    return rescale.component_lookup_tables();
+                }
+#endif
+
                 template<typename ContainerType>
                 explicit fix_dot_rescale_2_gates(ContainerType witness, uint32_t dots, uint8_t m2) :
                     component_type(witness, {}, {}, get_manifest(dots, m2)), dots(dots),
@@ -359,7 +370,7 @@ namespace nil {
 
                 using var =
                     typename plonk_fixedpoint_dot_rescale_2_gates<BlueprintFieldType, ArithmetizationParams>::var;
-                    
+
                 auto dots = component.get_dots();
                 auto dots_per_row = component.get_dots_per_row();
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_2_gates.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/dot_rescale_2_gates.hpp
@@ -105,7 +105,7 @@ namespace nil {
                     }
 
                     std::uint32_t gates_amount() const override {
-                        return rescale_component::gates_amount + 2;
+                        return fix_dot_rescale_2_gates::gates_amount;
                     }
                 };
 
@@ -137,6 +137,7 @@ namespace nil {
                     return rows;
                 }
 
+                constexpr static const std::size_t gates_amount = rescale_component::gates_amount + 2;
                 const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, dots, rescale.get_m2());
 
                 struct input_type {

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/exp.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/exp.hpp
@@ -181,19 +181,13 @@ namespace nil {
                         rescale.component_custom_lookup_tables();
 
                     if (m2 == 1) {
-                        auto table_a = std::shared_ptr<lookup_table_definition>(
-                            new fixedpoint_exp_a16_table<BlueprintFieldType>());
-                        auto table_b = std::shared_ptr<lookup_table_definition>(
-                            new fixedpoint_exp_b16_table<BlueprintFieldType>());
-                        result.push_back(table_a);
-                        result.push_back(table_b);
+                        auto table =
+                            std::shared_ptr<lookup_table_definition>(new fixedpoint_exp_16_table<BlueprintFieldType>());
+                        result.push_back(table);
                     } else if (m2 == 2) {
-                        auto table_a = std::shared_ptr<lookup_table_definition>(
-                            new fixedpoint_exp_a32_table<BlueprintFieldType>());
-                        auto table_b = std::shared_ptr<lookup_table_definition>(
-                            new fixedpoint_exp_b32_table<BlueprintFieldType>());
-                        result.push_back(table_a);
-                        result.push_back(table_b);
+                        auto table =
+                            std::shared_ptr<lookup_table_definition>(new fixedpoint_exp_32_table<BlueprintFieldType>());
+                        result.push_back(table);
                     } else {
                         BLUEPRINT_RELEASE_ASSERT(false);
                     }
@@ -205,14 +199,14 @@ namespace nil {
                     std::map<std::string, std::size_t> lookup_tables = rescale.component_lookup_tables();
 
                     if (m2 == 1) {
-                        lookup_tables[fixedpoint_exp_a16_table<BlueprintFieldType>::FULL_TABLE_NAME] =
+                        lookup_tables[fixedpoint_exp_16_table<BlueprintFieldType>::A_TABLE_NAME] =
                             0;    // REQUIRED_TABLE
-                        lookup_tables[fixedpoint_exp_b16_table<BlueprintFieldType>::FULL_TABLE_NAME] =
+                        lookup_tables[fixedpoint_exp_16_table<BlueprintFieldType>::B_TABLE_NAME] =
                             0;    // REQUIRED_TABLE
                     } else if (m2 == 2) {
-                        lookup_tables[fixedpoint_exp_a32_table<BlueprintFieldType>::FULL_TABLE_NAME] =
+                        lookup_tables[fixedpoint_exp_32_table<BlueprintFieldType>::A_TABLE_NAME] =
                             0;    // REQUIRED_TABLE
-                        lookup_tables[fixedpoint_exp_b32_table<BlueprintFieldType>::FULL_TABLE_NAME] =
+                        lookup_tables[fixedpoint_exp_32_table<BlueprintFieldType>::B_TABLE_NAME] =
                             0;    // REQUIRED_TABLE
                     } else {
                         BLUEPRINT_RELEASE_ASSERT(false);
@@ -397,12 +391,12 @@ namespace nil {
 
                 auto range_table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
                 auto exp_a_table_id =
-                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_exp_a16_table<BlueprintFieldType>::FULL_TABLE_NAME) :
-                              lookup_tables_indices.at(fixedpoint_exp_a32_table<BlueprintFieldType>::FULL_TABLE_NAME);
+                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_exp_16_table<BlueprintFieldType>::A_TABLE_NAME) :
+                              lookup_tables_indices.at(fixedpoint_exp_32_table<BlueprintFieldType>::A_TABLE_NAME);
 
                 auto exp_b_table_id =
-                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_exp_b16_table<BlueprintFieldType>::FULL_TABLE_NAME) :
-                              lookup_tables_indices.at(fixedpoint_exp_b32_table<BlueprintFieldType>::FULL_TABLE_NAME);
+                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_exp_16_table<BlueprintFieldType>::B_TABLE_NAME) :
+                              lookup_tables_indices.at(fixedpoint_exp_32_table<BlueprintFieldType>::B_TABLE_NAME);
 
                 constraint_type constraint_pre, constraint_post;
                 constraint_pre.table_id = exp_a_table_id;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/exp.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/exp.hpp
@@ -393,7 +393,7 @@ namespace nil {
                     typename plonk_fixedpoint_exp<BlueprintFieldType, ArithmetizationParams>::range_table;
 
                 std::vector<constraint_type> constraints;
-                constraints.reserve(2 + m2);
+                constraints.reserve(1 + 2 * m2);
 
                 auto range_table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
                 auto exp_a_table_id =
@@ -419,6 +419,16 @@ namespace nil {
 
                 constraints.push_back(constraint_pre);
                 constraints.push_back(constraint_post);
+
+                if (m2 == 2) {
+                    // We need to range check the second limb of x_post which does not go into the lookup table
+                    constraint_type constraint;
+                    constraint.table_id = range_table_id;
+
+                    auto x_post1 = var(var_pos.x_post0.column() + 1, var_pos.x_post0.row());
+                    constraint.lookup_input = {x_post1};
+                    constraints.push_back(constraint);
+                }
 
                 // Rescale
                 for (auto i = 0; i < m2; i++) {

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/exp_ranged.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/exp_ranged.hpp
@@ -307,7 +307,7 @@ namespace nil {
                 const typename plonk_fixedpoint_exp_ranged<BlueprintFieldType, ArithmetizationParams>::input_type
                     &instance_input) {
 
-                int64_t start_row_index = 1 - component.rows_amount;
+                int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
                 using var = typename plonk_fixedpoint_exp_ranged<BlueprintFieldType, ArithmetizationParams>::var;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/exp_ranged.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/exp_ranged.hpp
@@ -351,6 +351,7 @@ namespace nil {
                 std::size_t exp_selector = generate_exp_gates(component, bp, assignment, instance_input);
                 assignment.enable_selector(exp_selector, var_pos.exp_row);
 
+                auto exp_comp = component.get_exp_component();
 // Allows disabling the lookup tables for faster testing
 #ifndef TEST_WITHOUT_LOOKUP_TABLES
                 // Enable the lookup gates for exp
@@ -359,7 +360,6 @@ namespace nil {
 #endif
 
                 // Enable the copy constraints of exp
-                auto exp_comp = component.get_exp_component();
                 generate_copy_constraints(exp_comp, bp, assignment, instance_input, var_pos.exp_row);
 
                 // Finally, we have to put the min/max values into the constant columns

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/exp_ranged.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/exp_ranged.hpp
@@ -290,9 +290,9 @@ namespace nil {
 
                 // update output if out of range!
                 if (var_value(assignment, range_result.lt) == one) {
-                    assignment.witness(magic(var_pos.exp_pos.y)) = component.get_exp_min();
+                    assignment.witness(splat(var_pos.exp_pos.y)) = component.get_exp_min();
                 } else if (var_value(assignment, range_result.gt) == one) {
-                    assignment.witness(magic(var_pos.exp_pos.y)) = component.get_exp_max();
+                    assignment.witness(splat(var_pos.exp_pos.y)) = component.get_exp_max();
                 }
 
                 return exp_result;
@@ -316,12 +316,12 @@ namespace nil {
 
                 auto constraints = get_constraints(exp_comp, bp, assignment, instance_input);
 
-                auto in = var(magic(var_pos.range_pos.in));
-                auto lt = var(magic(var_pos.range_pos.lt));
-                auto gt = var(magic(var_pos.range_pos.gt));
-                auto y = var(magic(var_pos.exp_pos.y));
-                auto exp_min = var(magic(var_pos.exp_min), true, var::column_type::constant);
-                auto exp_max = var(magic(var_pos.exp_max), true, var::column_type::constant);
+                auto in = var(splat(var_pos.range_pos.in));
+                auto lt = var(splat(var_pos.range_pos.lt));
+                auto gt = var(splat(var_pos.range_pos.gt));
+                auto y = var(splat(var_pos.exp_pos.y));
+                auto exp_min = var(splat(var_pos.exp_min), true, var::column_type::constant);
+                auto exp_max = var(splat(var_pos.exp_max), true, var::column_type::constant);
 
                 constraints[0] *= in;
                 constraints[2] *= in;
@@ -381,8 +381,8 @@ namespace nil {
                 const std::size_t start_row_index) {
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
-                assignment.constant(magic(var_pos.exp_min)) = component.get_exp_min();
-                assignment.constant(magic(var_pos.exp_max)) = component.get_exp_max();
+                assignment.constant(splat(var_pos.exp_min)) = component.get_exp_min();
+                assignment.constant(splat(var_pos.exp_max)) = component.get_exp_max();
             }
 
         }    // namespace components

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/exp_ranged.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/exp_ranged.hpp
@@ -179,7 +179,7 @@ namespace nil {
                 class gate_manifest_type : public component_gate_manifest {
                 public:
                     std::uint32_t gates_amount() const override {
-                        return 4;    // includes the lookup gates
+                        return fix_exp_ranged::gates_amount;
                     }
                 };
 
@@ -202,6 +202,9 @@ namespace nil {
                            exp_component::get_rows_amount(witness_amount, lookup_column_amount);
                 }
 
+                // Includes the constraints + lookup_gates
+                constexpr static const std::size_t gates_amount =
+                    exp_component::gates_amount + range_component::gates_amount;
                 const std::size_t rows_amount =
                     get_rows_amount(this->witness_amount(), 0, range.get_m1(), range.get_m2());
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/gather_acc.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/gather_acc.hpp
@@ -115,12 +115,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_gather_acc &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.acc), false);
+                        output = var(splat(var_pos.acc), false);
                     }
 
                     result_type(const fix_gather_acc &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.acc), false);
+                        output = var(splat(var_pos.acc), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -168,24 +168,24 @@ namespace nil {
                 auto index_a_val = var_value(assignment, instance_input.index_a);
                 auto index_b_val = component.index_b;
 
-                assignment.witness(magic(var_pos.prev_acc)) = prev_acc_val;
-                assignment.witness(magic(var_pos.data)) = data_val;
-                assignment.witness(magic(var_pos.index_a)) = index_a_val;
+                assignment.witness(splat(var_pos.prev_acc)) = prev_acc_val;
+                assignment.witness(splat(var_pos.data)) = data_val;
+                assignment.witness(splat(var_pos.index_a)) = index_a_val;
 
                 auto diff = index_a_val - index_b_val;
 
                 if (diff == 0) {
                     // Does not matter what to put into inv
-                    assignment.witness(magic(var_pos.inv)) = BlueprintFieldType::value_type::zero();
-                    assignment.witness(magic(var_pos.eq)) = BlueprintFieldType::value_type::one();
+                    assignment.witness(splat(var_pos.inv)) = BlueprintFieldType::value_type::zero();
+                    assignment.witness(splat(var_pos.eq)) = BlueprintFieldType::value_type::one();
 
                     auto new_acc_val = prev_acc_val + data_val;
-                    assignment.witness(magic(var_pos.acc)) = new_acc_val;
+                    assignment.witness(splat(var_pos.acc)) = new_acc_val;
                 } else {
                     auto inv_val = diff.inversed();
-                    assignment.witness(magic(var_pos.eq)) = BlueprintFieldType::value_type::zero();
-                    assignment.witness(magic(var_pos.inv)) = inv_val;
-                    assignment.witness(magic(var_pos.acc)) = prev_acc_val;
+                    assignment.witness(splat(var_pos.eq)) = BlueprintFieldType::value_type::zero();
+                    assignment.witness(splat(var_pos.inv)) = inv_val;
+                    assignment.witness(splat(var_pos.acc)) = prev_acc_val;
                 }
 
                 return typename plonk_fixedpoint_gather_acc<BlueprintFieldType, ArithmetizationParams>::result_type(
@@ -206,13 +206,13 @@ namespace nil {
 
                 using var = typename plonk_fixedpoint_gather_acc<BlueprintFieldType, ArithmetizationParams>::var;
 
-                auto acc = var(magic(var_pos.acc));
-                auto prev_acc = var(magic(var_pos.prev_acc));
-                auto data = var(magic(var_pos.data));
-                auto eq = var(magic(var_pos.eq));
-                auto inv = var(magic(var_pos.inv));
-                auto index_a = var(magic(var_pos.index_a));
-                auto index_b = var(magic(var_pos.index_b), true, var::column_type::constant);
+                auto acc = var(splat(var_pos.acc));
+                auto prev_acc = var(splat(var_pos.prev_acc));
+                auto data = var(splat(var_pos.data));
+                auto eq = var(splat(var_pos.eq));
+                auto inv = var(splat(var_pos.inv));
+                auto index_a = var(splat(var_pos.index_a));
+                auto index_b = var(splat(var_pos.index_b), true, var::column_type::constant);
 
                 auto diff = index_a - index_b;
                 auto constraint_1 = diff * eq;
@@ -249,9 +249,9 @@ namespace nil {
 
                 using var = typename plonk_fixedpoint_gather_acc<BlueprintFieldType, ArithmetizationParams>::var;
 
-                auto prev_acc = var(magic(var_pos.prev_acc), false);
-                auto data = var(magic(var_pos.data), false);
-                auto index_a = var(magic(var_pos.index_a), false);
+                auto prev_acc = var(splat(var_pos.prev_acc), false);
+                auto data = var(splat(var_pos.data), false);
+                auto index_a = var(splat(var_pos.index_a), false);
 
                 bp.add_copy_constraint({instance_input.prev_acc, prev_acc});
                 bp.add_copy_constraint({instance_input.data, data});
@@ -291,7 +291,7 @@ namespace nil {
 
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
-                assignment.constant(magic(var_pos.index_b)) = component.index_b;
+                assignment.constant(splat(var_pos.index_b)) = component.index_b;
             }
 
         }    // namespace components

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/log.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/log.hpp
@@ -385,7 +385,7 @@ namespace nil {
                     &assignment,
                 const typename plonk_fixedpoint_log<BlueprintFieldType, ArithmetizationParams>::input_type
                     &instance_input) {
-                int64_t start_row_index = 1 - component.rows_amount;
+                int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(start_row_index);
                 auto m = component.get_m();
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/log.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/log.hpp
@@ -101,7 +101,7 @@ namespace nil {
                 class gate_manifest_type : public component_gate_manifest {
                 public:
                     std::uint32_t gates_amount() const override {
-                        return 6;
+                        return fix_log::gates_amount;
                     }
                 };
 
@@ -138,6 +138,7 @@ namespace nil {
                     return 2 * exp_rows + log_rows;
                 }
 
+                constexpr static const std::size_t gates_amount = exp_component::gates_amount + 2;
                 const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, get_m1(), get_m2());
                 const std::size_t log_rows_amount = get_log_rows_amount(this->witness_amount(), 0, get_m1(), get_m2());
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/log.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/log.hpp
@@ -223,12 +223,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_log &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     result_type(const fix_log &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -289,8 +289,8 @@ namespace nil {
                 typename plonk_fixedpoint_log<BlueprintFieldType, ArithmetizationParams>::exp_component::input_type
                     exp1_input,
                     exp2_input;
-                exp1_input.x = var(magic(var_pos.y), false);
-                exp2_input.x = var(magic(var_pos.exp2_in), false);
+                exp1_input.x = var(splat(var_pos.y), false);
+                exp2_input.x = var(splat(var_pos.exp2_in), false);
 
                 ////////////////////////////////////////////////////////
                 // Build the trace
@@ -304,9 +304,9 @@ namespace nil {
 
                 auto exp2_in_val = y_val - 1;
 
-                assignment.witness(magic(var_pos.x)) = x_val;
-                assignment.witness(magic(var_pos.y)) = y_val;
-                assignment.witness(magic(var_pos.exp2_in)) = exp2_in_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.exp2_in)) = exp2_in_val;
 
                 // Assign exp gadgets
                 auto exp1_out = generate_assignments(exp_comp, assignment, exp1_input, var_pos.exp1_row);
@@ -314,8 +314,8 @@ namespace nil {
 
                 auto exp1_out_val = var_value(assignment, exp1_out.output);
                 auto exp2_out_val = var_value(assignment, exp2_out.output);
-                assignment.witness(magic(var_pos.exp1_out)) = exp1_out_val;
-                assignment.witness(magic(var_pos.exp2_out)) = exp2_out_val;
+                assignment.witness(splat(var_pos.exp1_out)) = exp1_out_val;
+                assignment.witness(splat(var_pos.exp2_out)) = exp2_out_val;
 
                 // Decompositions
                 auto a_val = exp1_out_val - x_val;
@@ -357,18 +357,18 @@ namespace nil {
                 const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(start_row_index);
 
-                auto a0 = nil::crypto3::math::expression(var(magic(var_pos.a0)));
-                auto b0 = nil::crypto3::math::expression(var(magic(var_pos.b0)));
+                auto a0 = nil::crypto3::math::expression(var(splat(var_pos.a0)));
+                auto b0 = nil::crypto3::math::expression(var(splat(var_pos.b0)));
                 for (auto i = 1; i < m; i++) {
                     a0 += var(var_pos.a0.column() + i, var_pos.a0.row()) * (1ULL << (16 * i));
                     b0 += var(var_pos.b0.column() + i, var_pos.b0.row()) * (1ULL << (16 * i));
                 }
 
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
-                auto exp1_out = var(magic(var_pos.exp1_out));
-                auto exp2_in = var(magic(var_pos.exp2_in));
-                auto exp2_out = var(magic(var_pos.exp2_out));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto exp1_out = var(splat(var_pos.exp1_out));
+                auto exp2_in = var(splat(var_pos.exp2_in));
+                auto exp2_out = var(splat(var_pos.exp2_out));
 
                 auto constraint_1 = exp1_out - x - a0;
                 auto constraint_2 = x - exp2_out - 1 - b0;
@@ -438,9 +438,9 @@ namespace nil {
                 auto exp1_res = exp_comp.get_result((std::size_t)var_pos.exp1_row);
                 auto exp2_res = exp_comp.get_result((std::size_t)var_pos.exp2_row);
 
-                auto x = var(magic(var_pos.x));
-                auto exp1_out = var(magic(var_pos.exp1_out));
-                auto exp2_out = var(magic(var_pos.exp2_out));
+                auto x = var(splat(var_pos.x));
+                auto exp1_out = var(splat(var_pos.exp1_out));
+                auto exp2_out = var(splat(var_pos.exp2_out));
 
                 bp.add_copy_constraint({instance_input.x, x});
                 bp.add_copy_constraint({exp1_res.output, exp1_out});
@@ -466,8 +466,8 @@ namespace nil {
                 typename plonk_fixedpoint_log<BlueprintFieldType, ArithmetizationParams>::exp_component::input_type
                     exp1_input,
                     exp2_input;
-                exp1_input.x = var(magic(var_pos.y), false);
-                exp2_input.x = var(magic(var_pos.exp2_in), false);
+                exp1_input.x = var(splat(var_pos.y), false);
+                exp2_input.x = var(splat(var_pos.exp2_in), false);
 
                 // Enable the exp components
                 generate_circuit(exp_comp, bp, assignment, exp1_input, var_pos.exp1_row);

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/log.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/log.hpp
@@ -378,11 +378,11 @@ namespace nil {
 
             template<typename BlueprintFieldType, typename ArithmetizationParams>
             std::size_t generate_lookup_gates(
-                const plonk_fixedpoint_div<BlueprintFieldType, ArithmetizationParams> &component,
+                const plonk_fixedpoint_log<BlueprintFieldType, ArithmetizationParams> &component,
                 circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
                 assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                     &assignment,
-                const typename plonk_fixedpoint_div<BlueprintFieldType, ArithmetizationParams>::input_type
+                const typename plonk_fixedpoint_log<BlueprintFieldType, ArithmetizationParams>::input_type
                     &instance_input) {
                 int64_t start_row_index = 1 - component.rows_amount;
                 const auto var_pos = component.get_var_pos(start_row_index);
@@ -390,10 +390,10 @@ namespace nil {
 
                 const std::map<std::string, std::size_t> &lookup_tables_indices = bp.get_reserved_indices();
 
-                using var = typename plonk_fixedpoint_div<BlueprintFieldType, ArithmetizationParams>::var;
+                using var = typename plonk_fixedpoint_log<BlueprintFieldType, ArithmetizationParams>::var;
                 using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
                 using range_table =
-                    typename plonk_fixedpoint_div<BlueprintFieldType, ArithmetizationParams>::range_table;
+                    typename plonk_fixedpoint_log<BlueprintFieldType, ArithmetizationParams>::range_table;
 
                 std::vector<constraint_type> constraints;
                 constraints.reserve(2 * m);
@@ -401,7 +401,7 @@ namespace nil {
                 auto table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
                 BLUEPRINT_RELEASE_ASSERT(var_pos.a0.row() == var_pos.b0.row());
 
-                for (auto i = 0; i < m_; i++) {
+                for (auto i = 0; i < m; i++) {
                     constraint_type constraint_a, constraint_b;
                     constraint_a.table_id = table_id;
                     constraint_b.table_id = table_id;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/max.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/max.hpp
@@ -9,6 +9,8 @@
 #include <nil/blueprint/manifest.hpp>
 #include <nil/blueprint/basic_non_native_policy.hpp>
 
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp"
+
 namespace nil {
     namespace blueprint {
         namespace components {
@@ -63,6 +65,9 @@ namespace nil {
 
                 using var = typename component_type::var;
                 using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using range_table = fixedpoint_range_table<BlueprintFieldType>;
 
                 class gate_manifest_type : public component_gate_manifest {
                 public:
@@ -76,7 +81,6 @@ namespace nil {
                     return manifest;
                 }
 
-                // TACEO_TODO Update to lookup tables
                 static manifest_type get_manifest(uint8_t m1, uint8_t m2) {
                     static manifest_type manifest = manifest_type(
                         std::shared_ptr<manifest_param>(new manifest_single_value_param(5 + M(m2) + M(m1))), false);
@@ -88,7 +92,8 @@ namespace nil {
                     return 1;
                 }
 
-                constexpr static const std::size_t gates_amount = 1;
+                // Includes the constraints + lookup_gates
+                constexpr static const std::size_t gates_amount = 2;
                 const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0);
 
                 struct input_type {
@@ -141,6 +146,22 @@ namespace nil {
                         return {output};
                     }
                 };
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result = {};
+                    auto table = std::shared_ptr<lookup_table_definition>(new range_table());
+                    result.push_back(table);
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    return lookup_tables;
+                }
+#endif
 
                 template<typename ContainerType>
                 explicit fix_max(ContainerType witness, uint8_t m1, uint8_t m2) :
@@ -258,8 +279,44 @@ namespace nil {
                 auto constraint_2 = (s - 1) * (s + 1);
                 auto constraint_3 = z - inv2 * (s * (x - y) + x + y);
 
-                // TACEO_TODO extend for lookup constraint
                 return bp.add_gate({constraint_1, constraint_2, constraint_3});
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_fixedpoint_max<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_max<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m_ = component.get_m() + 1;
+
+                const std::map<std::string, std::size_t> &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_fixedpoint_max<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+                using range_table =
+                    typename plonk_fixedpoint_max<BlueprintFieldType, ArithmetizationParams>::range_table;
+
+                std::vector<constraint_type> constraints;
+                constraints.reserve(m_);
+
+                auto table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
+
+                for (auto i = 0; i < m_; i++) {
+                    constraint_type constraint;
+                    constraint.table_id = table_id;
+
+                    // We put row=0 here and enable the selector in the correct one
+                    auto di = var(var_pos.d0.column() + i, 0);
+                    constraint.lookup_input = {di};
+                    constraints.push_back(constraint);
+                }
+
+                return bp.add_lookup_gate(constraints);
             }
 
             template<typename BlueprintFieldType, typename ArithmetizationParams>
@@ -294,8 +351,13 @@ namespace nil {
 
                 std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
 
-                // TACEO_TODO extend for lookup?
                 assignment.enable_selector(selector_index, start_row_index);
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, start_row_index);
+#endif
 
                 generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/max.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/max.hpp
@@ -134,12 +134,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_max &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.z), false);
+                        output = var(splat(var_pos.z), false);
                     }
 
                     result_type(const fix_max &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.z), false);
+                        output = var(splat(var_pos.z), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -210,8 +210,8 @@ namespace nil {
                 auto tmp = x_val + y_val;
                 auto inv2 = typename BlueprintFieldType::value_type(2).inversed();
 
-                assignment.witness(magic(var_pos.x)) = x_val;
-                assignment.witness(magic(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
 
                 std::vector<uint16_t> d0_val;
 
@@ -223,8 +223,8 @@ namespace nil {
                 tmp += d_val;
                 tmp *= inv2;
                 auto z_val = tmp;
-                assignment.witness(magic(var_pos.z)) = z_val;
-                assignment.witness(magic(var_pos.s)) = sign ? -one : one;
+                assignment.witness(splat(var_pos.z)) = z_val;
+                assignment.witness(splat(var_pos.s)) = sign ? -one : one;
 
                 // Additional limb due to potential overflow of d_val
                 if (d0_val.size() > m) {
@@ -259,7 +259,7 @@ namespace nil {
                 // Output: z = max(x, y)
                 // is equivalent to: z = 2^-1 * (s * (x - y) + x + y)
 
-                auto d = nil::crypto3::math::expression(var(magic(var_pos.d0)));
+                auto d = nil::crypto3::math::expression(var(splat(var_pos.d0)));
                 for (auto i = 1; i < m; i++) {
                     d += var(var_pos.d0.column() + i, var_pos.d0.row()) * (1ULL << (16 * i));
                 }
@@ -268,10 +268,10 @@ namespace nil {
                 tmp *= 1ULL << 16;
                 d += var(var_pos.d0.column() + m, var_pos.d0.row()) * tmp;
 
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
-                auto z = var(magic(var_pos.z));
-                auto s = var(magic(var_pos.s));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto z = var(splat(var_pos.z));
+                auto s = var(splat(var_pos.s));
 
                 auto inv2 = typename BlueprintFieldType::value_type(2).inversed();
 
@@ -333,8 +333,8 @@ namespace nil {
 
                 using var = typename plonk_fixedpoint_max<BlueprintFieldType, ArithmetizationParams>::var;
 
-                var x = var(magic(var_pos.x), false);
-                var y = var(magic(var_pos.y), false);
+                var x = var(splat(var_pos.x), false);
+                var y = var(splat(var_pos.y), false);
                 bp.add_copy_constraint({instance_input.x, x});
                 bp.add_copy_constraint({instance_input.y, y});
             }

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/min.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/min.hpp
@@ -9,6 +9,8 @@
 #include <nil/blueprint/manifest.hpp>
 #include <nil/blueprint/basic_non_native_policy.hpp>
 
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp"
+
 namespace nil {
     namespace blueprint {
         namespace components {
@@ -63,6 +65,9 @@ namespace nil {
 
                 using var = typename component_type::var;
                 using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using range_table = fixedpoint_range_table<BlueprintFieldType>;
 
                 class gate_manifest_type : public component_gate_manifest {
                 public:
@@ -76,7 +81,6 @@ namespace nil {
                     return manifest;
                 }
 
-                // TACEO_TODO Update to lookup tables
                 static manifest_type get_manifest(uint8_t m1, uint8_t m2) {
                     static manifest_type manifest = manifest_type(
                         std::shared_ptr<manifest_param>(new manifest_single_value_param(5 + M(m2) + M(m1))), false);
@@ -88,7 +92,8 @@ namespace nil {
                     return 1;
                 }
 
-                constexpr static const std::size_t gates_amount = 1;
+                // Includes the constraints + lookup_gates
+                constexpr static const std::size_t gates_amount = 2;
                 const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0);
 
                 struct input_type {
@@ -141,6 +146,22 @@ namespace nil {
                         return {output};
                     }
                 };
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result = {};
+                    auto table = std::shared_ptr<lookup_table_definition>(new range_table());
+                    result.push_back(table);
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    return lookup_tables;
+                }
+#endif
 
                 template<typename ContainerType>
                 explicit fix_min(ContainerType witness, uint8_t m1, uint8_t m2) :
@@ -258,8 +279,44 @@ namespace nil {
                 auto constraint_2 = (s - 1) * (s + 1);
                 auto constraint_3 = z - inv2 * (s * (y - x) + x + y);
 
-                // TACEO_TODO extend for lookup constraint
                 return bp.add_gate({constraint_1, constraint_2, constraint_3});
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_fixedpoint_min<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_min<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m_ = component.get_m() + 1;
+
+                const std::map<std::string, std::size_t> &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_fixedpoint_min<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+                using range_table =
+                    typename plonk_fixedpoint_min<BlueprintFieldType, ArithmetizationParams>::range_table;
+
+                std::vector<constraint_type> constraints;
+                constraints.reserve(m_);
+
+                auto table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
+
+                for (auto i = 0; i < m_; i++) {
+                    constraint_type constraint;
+                    constraint.table_id = table_id;
+
+                    // We put row=0 here and enable the selector in the correct one
+                    auto di = var(var_pos.d0.column() + i, 0);
+                    constraint.lookup_input = {di};
+                    constraints.push_back(constraint);
+                }
+
+                return bp.add_lookup_gate(constraints);
             }
 
             template<typename BlueprintFieldType, typename ArithmetizationParams>
@@ -294,8 +351,13 @@ namespace nil {
 
                 std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
 
-                // TACEO_TODO extend for lookup?
                 assignment.enable_selector(selector_index, start_row_index);
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, start_row_index);
+#endif
 
                 generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/min.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/min.hpp
@@ -134,12 +134,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_min &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.z), false);
+                        output = var(splat(var_pos.z), false);
                     }
 
                     result_type(const fix_min &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.z), false);
+                        output = var(splat(var_pos.z), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -210,8 +210,8 @@ namespace nil {
                 auto tmp = x_val + y_val;
                 auto inv2 = typename BlueprintFieldType::value_type(2).inversed();
 
-                assignment.witness(magic(var_pos.x)) = x_val;
-                assignment.witness(magic(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
 
                 std::vector<uint16_t> d0_val;
 
@@ -223,8 +223,8 @@ namespace nil {
                 tmp -= d_val;
                 tmp *= inv2;
                 auto z_val = tmp;
-                assignment.witness(magic(var_pos.z)) = z_val;
-                assignment.witness(magic(var_pos.s)) = sign ? -one : one;
+                assignment.witness(splat(var_pos.z)) = z_val;
+                assignment.witness(splat(var_pos.s)) = sign ? -one : one;
 
                 // Additional limb due to potential overflow of d_val
                 if (d0_val.size() > m) {
@@ -259,7 +259,7 @@ namespace nil {
                 // Output: z = min(x, y)
                 // is equivalent to: z = 2^-1 * (s * (y - x) + x + y)
 
-                auto d = nil::crypto3::math::expression(var(magic(var_pos.d0)));
+                auto d = nil::crypto3::math::expression(var(splat(var_pos.d0)));
                 for (auto i = 1; i < m; i++) {
                     d += var(var_pos.d0.column() + i, var_pos.d0.row()) * (1ULL << (16 * i));
                 }
@@ -268,10 +268,10 @@ namespace nil {
                 tmp *= 1ULL << 16;
                 d += var(var_pos.d0.column() + m, var_pos.d0.row()) * tmp;
 
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
-                auto z = var(magic(var_pos.z));
-                auto s = var(magic(var_pos.s));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto z = var(splat(var_pos.z));
+                auto s = var(splat(var_pos.s));
 
                 auto inv2 = typename BlueprintFieldType::value_type(2).inversed();
 
@@ -333,8 +333,8 @@ namespace nil {
 
                 using var = typename plonk_fixedpoint_min<BlueprintFieldType, ArithmetizationParams>::var;
 
-                var x = var(magic(var_pos.x), false);
-                var y = var(magic(var_pos.y), false);
+                var x = var(splat(var_pos.x), false);
+                var y = var(splat(var_pos.y), false);
                 bp.add_copy_constraint({instance_input.x, x});
                 bp.add_copy_constraint({instance_input.y, y});
             }

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/mul_rescale.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/mul_rescale.hpp
@@ -10,6 +10,7 @@
 #include <nil/blueprint/basic_non_native_policy.hpp>
 
 #include "nil/blueprint/components/algebra/fixedpoint/type.hpp"
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp"
 
 namespace nil {
     namespace blueprint {
@@ -61,6 +62,9 @@ namespace nil {
 
                 using var = typename component_type::var;
                 using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using range_table = fixedpoint_range_table<BlueprintFieldType>;
 
                 class gate_manifest_type : public component_gate_manifest {
                 public:
@@ -74,9 +78,7 @@ namespace nil {
                     return manifest;
                 }
 
-                // TACEO_TODO Update to lookup tables
-                // we do not use _m1 but we need it for call to ManifestHelper
-                static manifest_type get_manifest(uint8_t _m1, uint8_t m2) {
+                static manifest_type get_manifest(uint8_t m2) {
                     static manifest_type manifest = manifest_type(
                         std::shared_ptr<manifest_param>(new manifest_single_value_param(3 + M(m2))), false);
                     return manifest;
@@ -87,7 +89,8 @@ namespace nil {
                     return 1;
                 }
 
-                constexpr static const std::size_t gates_amount = 1;
+                // Includes the constraints + lookup_gates
+                constexpr static const std::size_t gates_amount = 2;
                 const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0);
 
                 struct input_type {
@@ -137,15 +140,31 @@ namespace nil {
                     }
                 };
 
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result = {};
+                    auto table = std::shared_ptr<lookup_table_definition>(new range_table());
+                    result.push_back(table);
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    return lookup_tables;
+                }
+#endif
+
                 template<typename ContainerType>
                 explicit fix_mul_rescale(ContainerType witness, uint8_t m2) :
-                    component_type(witness, {}, {}, get_manifest(0, m2)), m2(M(m2)) {};
+                    component_type(witness, {}, {}, get_manifest(m2)), m2(M(m2)) {};
 
                 template<typename WitnessContainerType, typename ConstantContainerType,
                          typename PublicInputContainerType>
                 fix_mul_rescale(WitnessContainerType witness, ConstantContainerType constant,
                                 PublicInputContainerType public_input, uint8_t m2) :
-                    component_type(witness, constant, public_input, get_manifest(0, m2)),
+                    component_type(witness, constant, public_input, get_manifest(m2)),
                     m2(M(m2)) {};
 
                 fix_mul_rescale(std::initializer_list<typename component_type::witness_container_type::value_type>
@@ -155,7 +174,7 @@ namespace nil {
                                 std::initializer_list<typename component_type::public_input_container_type::value_type>
                                     public_inputs,
                                 uint8_t m2) :
-                    component_type(witnesses, constants, public_inputs, get_manifest(0, m2)),
+                    component_type(witnesses, constants, public_inputs, get_manifest(m2)),
                     m2(M(m2)) {};
             };
 
@@ -233,10 +252,45 @@ namespace nil {
                 auto y = var(magic(var_pos.y));
                 auto z = var(magic(var_pos.z));
 
-                auto constraint_1 = 2 * (x * y - z * delta - q) + delta;  // see the definition of rescale
+                auto constraint_1 = 2 * (x * y - z * delta - q) + delta;    // see the definition of rescale
 
-                // TACEO_TODO extend for lookup constraint
                 return bp.add_gate(constraint_1);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_fixedpoint_mul_rescale<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_mul_rescale<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                int64_t start_row_index = 0;
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m2 = component.get_m2();
+
+                const std::map<std::string, std::size_t> &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_fixedpoint_mul_rescale<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+                using range_table =
+                    typename plonk_fixedpoint_mul_rescale<BlueprintFieldType, ArithmetizationParams>::range_table;
+
+                std::vector<constraint_type> constraints;
+                constraints.reserve(m2);
+
+                auto table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
+
+                for (auto i = 0; i < m2; i++) {
+                    constraint_type constraint;
+                    constraint.table_id = table_id;
+
+                    auto qi = var(var_pos.q0.column() + i, var_pos.q0.row());
+                    constraint.lookup_input = {qi};
+                    constraints.push_back(constraint);
+                }
+
+                return bp.add_lookup_gate(constraints);
             }
 
             template<typename BlueprintFieldType, typename ArithmetizationParams>
@@ -248,11 +302,11 @@ namespace nil {
                 const typename plonk_fixedpoint_mul_rescale<BlueprintFieldType, ArithmetizationParams>::input_type
                     &instance_input,
                 const std::size_t start_row_index) {
-                    
+
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
                 using var = typename plonk_fixedpoint_mul_rescale<BlueprintFieldType, ArithmetizationParams>::var;
-                
+
                 var x = var(magic(var_pos.x), false);
                 var y = var(magic(var_pos.y), false);
                 bp.add_copy_constraint({instance_input.x, x});
@@ -270,10 +324,15 @@ namespace nil {
                         &instance_input,
                     const std::size_t start_row_index) {
 
-                // TACEO_TODO extend for lookup?
                 std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
 
                 assignment.enable_selector(selector_index, start_row_index);
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, start_row_index);
+#endif
 
                 generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/mul_rescale.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/mul_rescale.hpp
@@ -127,12 +127,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_mul_rescale &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.z), false);
+                        output = var(splat(var_pos.z), false);
                     }
 
                     result_type(const fix_mul_rescale &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.z), false);
+                        output = var(splat(var_pos.z), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -205,12 +205,12 @@ namespace nil {
                 auto z_val = res.quotient;
                 auto q_val = res.remainder;
 
-                assignment.witness(magic(var_pos.x)) = x_val;
-                assignment.witness(magic(var_pos.y)) = y_val;
-                assignment.witness(magic(var_pos.z)) = z_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.z)) = z_val;
 
                 if (component.get_m2() == 1) {
-                    assignment.witness(magic(var_pos.q0)) = q_val;
+                    assignment.witness(splat(var_pos.q0)) = q_val;
                 } else {
                     std::vector<uint16_t> q0_val;
                     bool sign = FixedPointHelper<BlueprintFieldType>::decompose(q_val, q0_val);
@@ -243,14 +243,14 @@ namespace nil {
                 // 2^16, hence q could be decomposed into 16-bit limbs
                 auto delta = component.get_delta();
 
-                auto q = nil::crypto3::math::expression(var(magic(var_pos.q0)));
+                auto q = nil::crypto3::math::expression(var(splat(var_pos.q0)));
                 for (auto i = 1; i < component.get_m2(); i++) {
                     q += var(var_pos.q0.column() + i, var_pos.q0.row()) * (1ULL << (16 * i));
                 }
 
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
-                auto z = var(magic(var_pos.z));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto z = var(splat(var_pos.z));
 
                 auto constraint_1 = 2 * (x * y - z * delta - q) + delta;    // see the definition of rescale
 
@@ -307,8 +307,8 @@ namespace nil {
 
                 using var = typename plonk_fixedpoint_mul_rescale<BlueprintFieldType, ArithmetizationParams>::var;
 
-                var x = var(magic(var_pos.x), false);
-                var y = var(magic(var_pos.y), false);
+                var x = var(splat(var_pos.x), false);
+                var y = var(splat(var_pos.y), false);
                 bp.add_copy_constraint({instance_input.x, x});
                 bp.add_copy_constraint({instance_input.y, y});
             }

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/mul_rescale_const.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/mul_rescale_const.hpp
@@ -130,12 +130,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_mul_rescale_const &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.z), false);
+                        output = var(splat(var_pos.z), false);
                     }
 
                     result_type(const fix_mul_rescale_const &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.z), false);
+                        output = var(splat(var_pos.z), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -203,11 +203,11 @@ namespace nil {
                 auto z_val = res.quotient;
                 auto q_val = res.remainder;
 
-                assignment.witness(magic(var_pos.x)) = x_val;
-                assignment.witness(magic(var_pos.z)) = z_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.z)) = z_val;
 
                 if (component.get_m2() == 1) {
-                    assignment.witness(magic(var_pos.q0)) = q_val;
+                    assignment.witness(splat(var_pos.q0)) = q_val;
                 } else {
                     std::vector<uint16_t> q0_val;
                     bool sign = FixedPointHelper<BlueprintFieldType>::decompose(q_val, q0_val);
@@ -241,14 +241,14 @@ namespace nil {
                 // 2^16, hence q could be decomposed into 16-bit limbs
                 auto delta = component.get_delta();
 
-                auto q = nil::crypto3::math::expression(var(magic(var_pos.q0)));
+                auto q = nil::crypto3::math::expression(var(splat(var_pos.q0)));
                 for (auto i = 1; i < component.get_m2(); i++) {
                     q += var(var_pos.q0.column() + i, var_pos.q0.row()) * (1ULL << (16 * i));
                 }
 
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y), true, var::column_type::constant);
-                auto z = var(magic(var_pos.z));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y), true, var::column_type::constant);
+                auto z = var(splat(var_pos.z));
 
                 auto constraint_1 = 2 * (x * y - z * delta - q) + delta;    // see the definition of rescale
 
@@ -305,7 +305,7 @@ namespace nil {
 
                 using var = typename plonk_fixedpoint_mul_rescale_const<BlueprintFieldType, ArithmetizationParams>::var;
 
-                var x = var(magic(var_pos.x), false);
+                var x = var(splat(var_pos.x), false);
                 bp.add_copy_constraint({instance_input.x, x});
             }
 
@@ -351,7 +351,7 @@ namespace nil {
 
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
-                assignment.constant(magic(var_pos.y)) = component.constant;
+                assignment.constant(splat(var_pos.y)) = component.constant;
             }
 
         }    // namespace components

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/neg.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/neg.hpp
@@ -45,7 +45,6 @@ namespace nil {
                     return manifest;
                 }
 
-                // TACEO_TODO Update to lookup tables
                 static manifest_type get_manifest() {
                     static manifest_type manifest =
                         manifest_type(std::shared_ptr<manifest_param>(new manifest_single_value_param(2)), false);
@@ -178,7 +177,7 @@ namespace nil {
                 using var = typename plonk_fixedpoint_neg<BlueprintFieldType, ArithmetizationParams>::var;
 
                 const auto var_pos = component.get_var_pos(start_row_index);
-                
+
                 var x = var(magic(var_pos.x), false);
                 bp.add_copy_constraint({instance_input.x, x});
             }
@@ -193,7 +192,6 @@ namespace nil {
                     &instance_input,
                 const std::size_t start_row_index) {
 
-                // TACEO_TODO extend for lookup?
                 std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
 
                 assignment.enable_selector(selector_index, start_row_index);

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/neg.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/neg.hpp
@@ -89,12 +89,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_neg &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(start_row_index);
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     result_type(const fix_neg &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(start_row_index);
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -135,8 +135,8 @@ namespace nil {
 
                 const auto var_pos = component.get_var_pos(start_row_index);
 
-                assignment.witness(magic(var_pos.x)) = var_value(assignment, instance_input.x);
-                assignment.witness(magic(var_pos.y)) = -var_value(assignment, instance_input.x);
+                assignment.witness(splat(var_pos.x)) = var_value(assignment, instance_input.x);
+                assignment.witness(splat(var_pos.y)) = -var_value(assignment, instance_input.x);
 
                 return typename plonk_fixedpoint_neg<BlueprintFieldType, ArithmetizationParams>::result_type(
                     component, start_row_index);
@@ -156,8 +156,8 @@ namespace nil {
                 uint64_t start_row_index = 0;
 
                 const auto var_pos = component.get_var_pos(start_row_index);
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
 
                 auto constraint_1 = x + y;
 
@@ -178,7 +178,7 @@ namespace nil {
 
                 const auto var_pos = component.get_var_pos(start_row_index);
 
-                var x = var(magic(var_pos.x), false);
+                var x = var(splat(var_pos.x), false);
                 bp.add_copy_constraint({instance_input.x, x});
             }
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/range.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/range.hpp
@@ -230,16 +230,16 @@ namespace nil {
 
                     result_type(const fix_range &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        in = var(magic(var_pos.in), false);
-                        lt = var(magic(var_pos.lt), false);
-                        gt = var(magic(var_pos.gt), false);
+                        in = var(splat(var_pos.in), false);
+                        lt = var(splat(var_pos.lt), false);
+                        gt = var(splat(var_pos.gt), false);
                     }
 
                     result_type(const fix_range &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        in = var(magic(var_pos.in), false);
-                        lt = var(magic(var_pos.lt), false);
-                        gt = var(magic(var_pos.gt), false);
+                        in = var(splat(var_pos.in), false);
+                        lt = var(splat(var_pos.lt), false);
+                        gt = var(splat(var_pos.gt), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -306,7 +306,7 @@ namespace nil {
 
                 auto x_val = var_value(assignment, instance_input.x);
 
-                assignment.witness(magic(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
 
                 auto a_val = x_val - component.get_x_lo();
                 auto b_val = component.get_x_hi() - x_val;
@@ -324,22 +324,22 @@ namespace nil {
                 BLUEPRINT_RELEASE_ASSERT(a0_val.size() >= m);
                 BLUEPRINT_RELEASE_ASSERT(b0_val.size() >= m);
 
-                assignment.witness(magic(var_pos.in)) = (!sign_a && !sign_b) ? one : zero;
-                assignment.witness(magic(var_pos.lt)) = sign_a ? one : zero;
-                assignment.witness(magic(var_pos.gt)) = sign_b ? one : zero;
+                assignment.witness(splat(var_pos.in)) = (!sign_a && !sign_b) ? one : zero;
+                assignment.witness(splat(var_pos.lt)) = sign_a ? one : zero;
+                assignment.witness(splat(var_pos.gt)) = sign_b ? one : zero;
                 BLUEPRINT_RELEASE_ASSERT(!sign_a || !sign_b);
 
                 bool eq_a = a_val == 0;
                 bool eq_b = b_val == 0;
-                assignment.witness(magic(var_pos.z_a)) = eq_a ? one : zero;
-                assignment.witness(magic(var_pos.z_b)) = eq_b ? one : zero;
+                assignment.witness(splat(var_pos.z_a)) = eq_a ? one : zero;
+                assignment.witness(splat(var_pos.z_b)) = eq_b ? one : zero;
 
                 // if eq: Does not matter what to put here
-                assignment.witness(magic(var_pos.inv_a)) = eq_a ? zero : a_val.inversed();
-                assignment.witness(magic(var_pos.inv_b)) = eq_b ? zero : b_val.inversed();
+                assignment.witness(splat(var_pos.inv_a)) = eq_a ? zero : a_val.inversed();
+                assignment.witness(splat(var_pos.inv_b)) = eq_b ? zero : b_val.inversed();
 
-                assignment.witness(magic(var_pos.s_a)) = sign_a ? -one : one;
-                assignment.witness(magic(var_pos.s_b)) = sign_b ? -one : one;
+                assignment.witness(splat(var_pos.s_a)) = sign_a ? -one : one;
+                assignment.witness(splat(var_pos.s_b)) = sign_b ? -one : one;
 
                 // Additional limb due to potential overflow of diff
                 // FixedPointHelper::decompose creates a vector whose size is a multiple of 4.
@@ -383,8 +383,8 @@ namespace nil {
 
                 auto m = component.get_m();
 
-                auto a0 = nil::crypto3::math::expression(var(magic(var_pos.a0)));
-                auto b0 = nil::crypto3::math::expression(var(magic(var_pos.b0)));
+                auto a0 = nil::crypto3::math::expression(var(splat(var_pos.a0)));
+                auto b0 = nil::crypto3::math::expression(var(splat(var_pos.b0)));
                 for (auto i = 1; i < m; i++) {
                     a0 += var(var_pos.a0.column() + i, var_pos.a0.row()) * (1ULL << (16 * i));
                     b0 += var(var_pos.b0.column() + i, var_pos.b0.row()) * (1ULL << (16 * i));
@@ -395,18 +395,18 @@ namespace nil {
                 a0 += var(var_pos.a0.column() + m, var_pos.a0.row()) * tmp;
                 b0 += var(var_pos.b0.column() + m, var_pos.b0.row()) * tmp;
 
-                auto x = var(magic(var_pos.x));
-                auto in = var(magic(var_pos.in));
-                auto lt = var(magic(var_pos.lt));
-                auto gt = var(magic(var_pos.gt));
-                auto z_a = var(magic(var_pos.z_a));
-                auto z_b = var(magic(var_pos.z_b));
-                auto inv_a = var(magic(var_pos.inv_a));
-                auto inv_b = var(magic(var_pos.inv_b));
-                auto s_a = var(magic(var_pos.s_a));
-                auto s_b = var(magic(var_pos.s_b));
-                auto x_l = var(magic(var_pos.x_l), true, var::column_type::constant);
-                auto x_h = var(magic(var_pos.x_h), true, var::column_type::constant);
+                auto x = var(splat(var_pos.x));
+                auto in = var(splat(var_pos.in));
+                auto lt = var(splat(var_pos.lt));
+                auto gt = var(splat(var_pos.gt));
+                auto z_a = var(splat(var_pos.z_a));
+                auto z_b = var(splat(var_pos.z_b));
+                auto inv_a = var(splat(var_pos.inv_a));
+                auto inv_b = var(splat(var_pos.inv_b));
+                auto s_a = var(splat(var_pos.s_a));
+                auto s_b = var(splat(var_pos.s_b));
+                auto x_l = var(splat(var_pos.x_l), true, var::column_type::constant);
+                auto x_h = var(splat(var_pos.x_h), true, var::column_type::constant);
 
                 auto inv2 = typename BlueprintFieldType::value_type(2).inversed();
 
@@ -481,7 +481,7 @@ namespace nil {
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
                 using var = typename plonk_fixedpoint_range<BlueprintFieldType, ArithmetizationParams>::var;
-                var x = var(magic(var_pos.x), false);
+                var x = var(splat(var_pos.x), false);
                 bp.add_copy_constraint({instance_input.x, x});
             }
 
@@ -523,8 +523,8 @@ namespace nil {
                     &instance_input,
                 const std::size_t start_row_index) {
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                assignment.constant(magic(var_pos.x_l)) = component.get_x_lo();
-                assignment.constant(magic(var_pos.x_h)) = component.get_x_hi();
+                assignment.constant(splat(var_pos.x_l)) = component.get_x_lo();
+                assignment.constant(splat(var_pos.x_h)) = component.get_x_hi();
             }
 
         }    // namespace components

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/range.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/range.hpp
@@ -10,6 +10,7 @@
 #include <nil/blueprint/basic_non_native_policy.hpp>
 
 #include "nil/blueprint/components/algebra/fixedpoint/type.hpp"
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp"
 
 namespace nil {
     namespace blueprint {
@@ -98,6 +99,9 @@ namespace nil {
 
                 using var = typename component_type::var;
                 using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using range_table = fixedpoint_range_table<BlueprintFieldType>;
 
                 class gate_manifest_type : public component_gate_manifest {
                 public:
@@ -111,7 +115,6 @@ namespace nil {
                     return manifest;
                 }
 
-                // TACEO_TODO Update to lookup tables
                 static manifest_type get_manifest(uint8_t m1, uint8_t m2) {
                     static manifest_type manifest = manifest_type(
                         std::shared_ptr<manifest_param>(new manifest_range_param(10, 10 + 2 * (m2 + m1 + 1))), false);
@@ -127,7 +130,8 @@ namespace nil {
                     }
                 }
 
-                constexpr static const std::size_t gates_amount = 1;
+                // Includes the constraints + lookup_gates
+                constexpr static const std::size_t gates_amount = 2;
                 const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, m1, m2);
 
                 struct input_type {
@@ -242,6 +246,22 @@ namespace nil {
                         return {in, lt, gt};
                     }
                 };
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result = {};
+                    auto table = std::shared_ptr<lookup_table_definition>(new range_table());
+                    result.push_back(table);
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    return lookup_tables;
+                }
+#endif
 
                 template<typename WitnessContainerType, typename ConstantContainerType,
                          typename PublicInputContainerType>
@@ -402,9 +422,50 @@ namespace nil {
                 auto constraint_10 = gt - inv2 * (1 - s_b) * (1 - z_b);
                 auto constraint_11 = in - (1 - lt) * (1 - gt);
 
-                // TACEO_TODO extend for lookup constraint
                 return bp.add_gate({constraint_1, constraint_2, constraint_3, constraint_4, constraint_5, constraint_6,
                                     constraint_7, constraint_8, constraint_9, constraint_10, constraint_11});
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_fixedpoint_range<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_range<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m = component.get_m();
+
+                const std::map<std::string, std::size_t> &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_fixedpoint_range<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+                using range_table =
+                    typename plonk_fixedpoint_range<BlueprintFieldType, ArithmetizationParams>::range_table;
+
+                std::vector<constraint_type> constraints;
+                constraints.reserve(2 * m);
+
+                auto table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
+                BLUEPRINT_RELEASE_ASSERT(var_pos.a0.row() == var_pos.b0.row());
+
+                for (auto i = 0; i < m; i++) {
+                    constraint_type constraint_a, constraint_b;
+                    constraint_a.table_id = table_id;
+                    constraint_b.table_id = table_id;
+
+                    // We put row=0 here and enable the selector in the correct one
+                    auto ai = var(var_pos.a0.column() + i, 0);
+                    auto bi = var(var_pos.b0.column() + i, 0);
+                    constraint_a.lookup_input = {ai};
+                    constraint_b.lookup_input = {bi};
+                    constraints.push_back(constraint_a);
+                    constraints.push_back(constraint_b);
+                }
+
+                return bp.add_lookup_gate(constraints);
             }
 
             template<typename BlueprintFieldType, typename ArithmetizationParams>
@@ -434,11 +495,17 @@ namespace nil {
                     &instance_input,
                 const std::size_t start_row_index) {
 
-                // TACEO_TODO extend for lookup?
                 std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
 
                 // selector goes onto last row and gate uses all rows
                 assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, var_pos.a0.row());    // same as b0.row()
+#endif
 
                 generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
                 generate_assignments_constant(component, assignment, instance_input, start_row_index);

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/range.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/range.hpp
@@ -436,7 +436,7 @@ namespace nil {
                     &instance_input) {
                 const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(start_row_index);
-                auto m = component.get_m();
+                auto m_ = component.get_m() + 1;
 
                 const std::map<std::string, std::size_t> &lookup_tables_indices = bp.get_reserved_indices();
 
@@ -446,12 +446,12 @@ namespace nil {
                     typename plonk_fixedpoint_range<BlueprintFieldType, ArithmetizationParams>::range_table;
 
                 std::vector<constraint_type> constraints;
-                constraints.reserve(2 * m);
+                constraints.reserve(2 * m_);
 
                 auto table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
                 BLUEPRINT_RELEASE_ASSERT(var_pos.a0.row() == var_pos.b0.row());
 
-                for (auto i = 0; i < m; i++) {
+                for (auto i = 0; i < m_; i++) {
                     constraint_type constraint_a, constraint_b;
                     constraint_a.table_id = table_id;
                     constraint_b.table_id = table_id;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/rem.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/rem.hpp
@@ -242,10 +242,10 @@ namespace nil {
                 const std::uint32_t start_row_index) {
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
-                auto x_val = var_value(assignment, instance_input.x) * component.x_scaler;
+                auto x_val = var_value(assignment, instance_input.x);
                 auto y_val = var_value(assignment, instance_input.y);
 
-                DivMod<BlueprintFieldType> tmp = FixedPointHelper<BlueprintFieldType>::div_mod(x_val, y_val);
+                DivMod<BlueprintFieldType> tmp = FixedPointHelper<BlueprintFieldType>::div_mod(x_val * component.x_scaler, y_val);
                 if (y_val > FixedPointHelper<BlueprintFieldType>::P_HALF && tmp.remainder != 0) {
                     // sign(other.value) == sign(divmod_remainder)
                     tmp.remainder += y_val;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/rem.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/rem.hpp
@@ -172,12 +172,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_rem &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.z), false);
+                        output = var(splat(var_pos.z), false);
                     }
 
                     result_type(const fix_rem &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.z), false);
+                        output = var(splat(var_pos.z), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -247,9 +247,9 @@ namespace nil {
                 }
                 auto z_val = tmp.remainder;
 
-                assignment.witness(magic(var_pos.x)) = x_val;
-                assignment.witness(magic(var_pos.y)) = y_val;
-                assignment.witness(magic(var_pos.z)) = z_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.z)) = z_val;
 
                 std::vector<uint16_t> y0_val;
                 std::vector<uint16_t> z0_val;
@@ -263,11 +263,11 @@ namespace nil {
                 bool sign_y_ = FixedPointHelper<BlueprintFieldType>::decompose(y_abs, y0_val);
                 BLUEPRINT_RELEASE_ASSERT(!sign_y_);
                 auto s_y_val = sign_y ? -one : one;
-                assignment.witness(magic(var_pos.s_y)) = s_y_val;
+                assignment.witness(splat(var_pos.s_y)) = s_y_val;
 
                 bool sign_a = FixedPointHelper<BlueprintFieldType>::decompose(tmp.quotient, a0_val);
                 auto s_a_val = sign_a ? -one : one;
-                assignment.witness(magic(var_pos.s_a)) = s_a_val;
+                assignment.witness(splat(var_pos.s_a)) = s_a_val;
 
                 auto z_abs = z_val;
                 bool sign_z = FixedPointHelper<BlueprintFieldType>::abs(z_abs);
@@ -310,10 +310,10 @@ namespace nil {
                 const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(start_row_index);
 
-                auto y0 = nil::crypto3::math::expression(var(magic(var_pos.y0)));
-                auto z0 = nil::crypto3::math::expression(var(magic(var_pos.z0)));
-                auto a0 = nil::crypto3::math::expression(var(magic(var_pos.a0)));
-                auto d0 = nil::crypto3::math::expression(var(magic(var_pos.d0)));
+                auto y0 = nil::crypto3::math::expression(var(splat(var_pos.y0)));
+                auto z0 = nil::crypto3::math::expression(var(splat(var_pos.z0)));
+                auto a0 = nil::crypto3::math::expression(var(splat(var_pos.a0)));
+                auto d0 = nil::crypto3::math::expression(var(splat(var_pos.d0)));
                 for (auto i = 1; i < m; i++) {
                     y0 += var(var_pos.y0.column() + i, var_pos.y0.row()) * (1ULL << (16 * i));
                     z0 += var(var_pos.z0.column() + i, var_pos.z0.row()) * (1ULL << (16 * i));
@@ -321,11 +321,11 @@ namespace nil {
                     d0 += var(var_pos.d0.column() + i, var_pos.d0.row()) * (1ULL << (16 * i));
                 }
 
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
-                auto z = var(magic(var_pos.z));
-                auto s_a = var(magic(var_pos.s_a));
-                auto s_y = var(magic(var_pos.s_y));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto z = var(splat(var_pos.z));
+                auto s_a = var(splat(var_pos.s_a));
+                auto s_y = var(splat(var_pos.s_y));
 
                 auto constraint_1 = x - s_a * a0 * y - z;
                 auto constraint_2 = y - s_y * y0;
@@ -417,8 +417,8 @@ namespace nil {
 
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
                 bp.add_copy_constraint({instance_input.x, x});
                 bp.add_copy_constraint({instance_input.y, y});
             }

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/rem.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/rem.hpp
@@ -61,6 +61,11 @@ namespace nil {
                     return m2;
                 }
 
+                static std::size_t get_witness_columns(std::size_t witness_amount, uint8_t m1, uint8_t m2) {
+                    return get_rows_amount(witness_amount, 0, M(m1), M(m2)) == 1 ? 5 + 4 * (m1 + m2) :
+                                                                                   3 + 2 * (m1 + m2);
+                }
+
                 using component_type = plonk_component<BlueprintFieldType, ArithmetizationParams, 0, 0>;
 
                 using var = typename component_type::var;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/rescale.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/rescale.hpp
@@ -137,12 +137,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_rescale &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     result_type(const fix_rescale &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -210,11 +210,11 @@ namespace nil {
                 auto y_val = tmp.quotient;
                 auto q_val = tmp.remainder;
 
-                assignment.witness(magic(var_pos.x)) = x_val;
-                assignment.witness(magic(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
 
                 if (component.get_m2() == 1) {
-                    assignment.witness(magic(var_pos.q0)) = q_val;    // q0
+                    assignment.witness(splat(var_pos.q0)) = q_val;    // q0
                 } else {
                     std::vector<uint16_t> decomp;
                     bool sign = FixedPointHelper<BlueprintFieldType>::decompose(q_val, decomp);
@@ -249,13 +249,13 @@ namespace nil {
                 using var = typename plonk_fixedpoint_rescale<BlueprintFieldType, ArithmetizationParams>::var;
                 auto delta = component.get_delta();
 
-                auto q = nil::crypto3::math::expression(var(magic(var_pos.q0)));
+                auto q = nil::crypto3::math::expression(var(splat(var_pos.q0)));
                 for (auto i = 1; i < component.get_m2(); i++) {
                     q += var(var_pos.q0.column() + i, var_pos.q0.row()) * (1ULL << (16 * i));    // qi for i in [0, m2)
                 }
 
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
 
                 auto constraint = 2 * (x - y * delta - q) + delta;
 
@@ -325,7 +325,7 @@ namespace nil {
 
                 using var = typename plonk_fixedpoint_rescale<BlueprintFieldType, ArithmetizationParams>::var;
 
-                auto x = var(magic(var_pos.x), false);
+                auto x = var(splat(var_pos.x), false);
                 bp.add_copy_constraint({instance_input.x, x});
             }
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/rescale.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/rescale.hpp
@@ -283,7 +283,7 @@ namespace nil {
                     &assignment,
                 const typename plonk_fixedpoint_rescale<BlueprintFieldType, ArithmetizationParams>::input_type
                     &instance_input) {
-                int64_t start_row_index = 0;
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(start_row_index);
                 auto m2 = component.get_m2();
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/rescale.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/rescale.hpp
@@ -159,7 +159,7 @@ namespace nil {
 
                 std::map<std::string, std::size_t> component_lookup_tables() {
                     std::map<std::string, std::size_t> lookup_tables;
-                    lookup_tables[range_table::SUBTABLE_NAME] = 0;    // REQUIRED_TABLE
+                    lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
                     return lookup_tables;
                 }
 
@@ -294,7 +294,7 @@ namespace nil {
                 std::vector<constraint_type> constraints;
                 constraints.reserve(m2);
 
-                auto table_id = lookup_tables_indices.at(range_table::SUBTABLE_NAME);
+                auto table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
 
                 for (auto i = 0; i < m2; i++) {
                     constraint_type constraint;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/rescale.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/rescale.hpp
@@ -150,6 +150,8 @@ namespace nil {
                     }
                 };
 
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
                 std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
                     std::vector<std::shared_ptr<lookup_table_definition>> result = {};
                     auto table = std::shared_ptr<lookup_table_definition>(new range_table());
@@ -162,6 +164,7 @@ namespace nil {
                     lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
                     return lookup_tables;
                 }
+#endif
 
                 template<typename ContainerType>
                 explicit fix_rescale(ContainerType witness, uint8_t m2) :
@@ -339,8 +342,11 @@ namespace nil {
                 std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
                 assignment.enable_selector(selector_index, start_row_index);
 
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
                 std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
                 assignment.enable_selector(lookup_selector_index, start_row_index);
+#endif
 
                 generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/select.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/select.hpp
@@ -100,12 +100,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_select &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(start_row_index);
-                        output = var(magic(var_pos.z), false);
+                        output = var(splat(var_pos.z), false);
                     }
 
                     result_type(const fix_select &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(start_row_index);
-                        output = var(magic(var_pos.z), false);
+                        output = var(splat(var_pos.z), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -156,10 +156,10 @@ namespace nil {
                 const auto var_pos = component.get_var_pos(start_row_index);
 
                 // writing the values of the inputs/output to this gate's internal state variables
-                assignment.witness(magic(var_pos.c)) = c_val;
-                assignment.witness(magic(var_pos.x)) = x_val;
-                assignment.witness(magic(var_pos.y)) = y_val;
-                assignment.witness(magic(var_pos.z)) = z_val;
+                assignment.witness(splat(var_pos.c)) = c_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.z)) = z_val;
 
                 return typename plonk_fixedpoint_select<BlueprintFieldType, ArithmetizationParams>::result_type(
                     component, start_row_index);
@@ -180,10 +180,10 @@ namespace nil {
 
                 const auto var_pos = component.get_var_pos(start_row_index);
 
-                auto c = var(magic(var_pos.c));
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
-                auto z = var(magic(var_pos.z));
+                auto c = var(splat(var_pos.c));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto z = var(splat(var_pos.z));
 
                 // Output: z = c == true ? x : y
                 // is equivalent to: z = c * (x - y) + y
@@ -207,9 +207,9 @@ namespace nil {
 
                 const auto var_pos = component.get_var_pos(start_row_index);
 
-                auto c = var(magic(var_pos.c), false);
-                auto x = var(magic(var_pos.x), false);
-                auto y = var(magic(var_pos.y), false);
+                auto c = var(splat(var_pos.c), false);
+                auto x = var(splat(var_pos.x), false);
+                auto y = var(splat(var_pos.y), false);
 
                 bp.add_copy_constraint({instance_input.c, c});
                 bp.add_copy_constraint({instance_input.x, x});

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
@@ -522,6 +522,7 @@ namespace nil {
                 std::vector<constraint_type> constraints;
 
                 // lookup decomposition of x
+                // TODO not required, as this is covered by the sin/cos lookup tables
                 for (size_t i = 0; i < m2 + 1; i++) {
                     constraint_type constraint;
                     constraint.table_id = range_table_id;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
@@ -194,12 +194,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_sin &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     result_type(const fix_sin &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -255,16 +255,16 @@ namespace nil {
                 auto delta = value_type(component.get_delta());
 
                 auto x_val = var_value(assignment, instance_input.x);
-                assignment.witness(magic(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
                 std::vector<uint16_t> x0_val;
                 auto x_reduced_val = x_val;    // x_reduced guarantees the use of only one pre-comma limb
                 if (m1 == 2) {                 // if two pre-comma limbs are used, x is reduced mod 2*pi
-                    assignment.constant(magic(var_pos.two_pi)) = component.two_pi;
+                    assignment.constant(splat(var_pos.two_pi)) = component.two_pi;
                     auto rem_component = component.get_rem_component();
                     typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::rem_component::input_type
                         rem_input;
-                    rem_input.x = var(magic(var_pos.x));
-                    rem_input.y = var(magic(var_pos.two_pi), true, var::column_type::constant);
+                    rem_input.x = var(splat(var_pos.x));
+                    rem_input.y = var(splat(var_pos.two_pi), true, var::column_type::constant);
                     auto rem_result = generate_assignments(rem_component, assignment, rem_input, var_pos.rem_row);
                     x_reduced_val = var_value(assignment, rem_result.output);
                 }
@@ -274,7 +274,7 @@ namespace nil {
                 }
                 auto s_x_val = sign ? -one : one;
                 BLUEPRINT_RELEASE_ASSERT(x0_val.size() >= (m2 + 1));
-                assignment.witness(magic(var_pos.s_x)) = s_x_val;
+                assignment.witness(splat(var_pos.s_x)) = s_x_val;
                 for (size_t i = 0; i < m2 + 1; i++) {
                     assignment.witness(var_pos.x0.column() + i, var_pos.x0.row()) = x0_val[i];
                 }
@@ -296,13 +296,13 @@ namespace nil {
                 auto cos1_val = cos_b_table[x0_val[m2 - 1]];
                 auto cos2_val = delta;
 
-                assignment.witness(magic(var_pos.sin0)) = sin0_val;
+                assignment.witness(splat(var_pos.sin0)) = sin0_val;
                 assignment.witness(var_pos.sin0.column() + 1, var_pos.sin0.row()) = sin1_val;
                 if (m2 == 2) {
                     assignment.witness(var_pos.sin0.column() + 2, var_pos.sin0.row()) = sin2_val;
                 }
-                assignment.witness(magic(var_pos.cos0)) = cos0_val;
-                assignment.witness(magic(var_pos.cos1)) = cos1_val;
+                assignment.witness(splat(var_pos.cos0)) = cos0_val;
+                assignment.witness(splat(var_pos.cos1)) = cos1_val;
 
                 // sin(-a)    = -sin(a)
                 // sin(a+b)   = sin(a)cos(b) + cos(a)sin(b)
@@ -319,10 +319,10 @@ namespace nil {
                 auto y_val = tmp.quotient;
                 auto q_val = tmp.remainder;
 
-                assignment.witness(magic(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
 
                 if (m2 == 1) {
-                    assignment.witness(magic(var_pos.q0)) = q_val;
+                    assignment.witness(splat(var_pos.q0)) = q_val;
                 } else {    // m2 == 2
                     std::vector<uint16_t> q0_val;
                     bool sign_ = FixedPointHelper<BlueprintFieldType>::decompose(q_val, q0_val);
@@ -354,9 +354,9 @@ namespace nil {
                 auto m = component.get_m();
 
                 auto delta = typename BlueprintFieldType::value_type(component.get_delta());
-                auto x = var(magic(var_pos.x));
-                auto s_x = var(magic(var_pos.s_x));
-                auto x0 = nil::crypto3::math::expression(var(magic(var_pos.x0)));
+                auto x = var(splat(var_pos.x));
+                auto s_x = var(splat(var_pos.s_x));
+                auto x0 = nil::crypto3::math::expression(var(splat(var_pos.x0)));
 
                 // decomposition of x
                 for (size_t i = 1; i < m2 + 1; i++) {
@@ -373,14 +373,14 @@ namespace nil {
                 // sign of x
                 auto constraint_2 = (s_x - 1) * (s_x + 1);
 
-                auto y = var(magic(var_pos.y));
-                auto sin0 = var(magic(var_pos.sin0));
+                auto y = var(splat(var_pos.y));
+                auto sin0 = var(splat(var_pos.sin0));
                 auto sin1 = var(var_pos.sin0.column() + 1, var_pos.sin0.row());
-                auto cos0 = var(magic(var_pos.cos0));
-                auto cos1 = var(magic(var_pos.cos1));
+                auto cos0 = var(splat(var_pos.cos0));
+                auto cos1 = var(splat(var_pos.cos1));
                 auto sin2 = var(var_pos.sin0.column() + 2, var_pos.sin0.row());
                 auto cos2 = delta;
-                auto q = nil::crypto3::math::expression(var(magic(var_pos.q0)));
+                auto q = nil::crypto3::math::expression(var(splat(var_pos.q0)));
                 for (size_t i = 1; i < m2 * m2; i++) {
                     q += var(var_pos.q0.column() + i, var_pos.q0.row()) * (1ULL << (16 * i));
                 }
@@ -420,7 +420,7 @@ namespace nil {
                 const std::size_t start_row_index) {
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
                 using var = typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::var;
-                var x = var(magic(var_pos.x), false);
+                var x = var(splat(var_pos.x), false);
                 bp.add_copy_constraint({instance_input.x, x});
             }
 
@@ -440,8 +440,8 @@ namespace nil {
 
                     using var = typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::var;
 
-                    rem_input.x = var(magic(var_pos.x), false);
-                    rem_input.y = var(magic(var_pos.two_pi), false, var::column_type::constant);
+                    rem_input.x = var(splat(var_pos.x), false);
+                    rem_input.y = var(splat(var_pos.two_pi), false, var::column_type::constant);
 
                     generate_circuit(component.get_rem_component(), bp, assignment, rem_input, var_pos.rem_row);
                 }

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
@@ -1,0 +1,464 @@
+#ifndef CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_SIN_HPP
+#define CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_SIN_HPP
+
+#include "nil/blueprint/components/algebra/fixedpoint/plonk/rem.hpp"
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+
+            // Works by decomposing x into up to three limbs and using the identities sin(a+b) = sin(a)cos(b) +
+            // cos(a)sin(b) and cos(a+b) = cos(a)cos(b) - sin(a)sin(b) multiple times, followed by one custom rescale
+            // operation. The evaluations of sin and cos are retrieved via pre-computed lookup tables. In case m1 >= 2,
+            // a rem operation (mod 2*pi) brings x into a range where one pre-comma limb is sufficient for computing
+            // sin(x).
+
+            /**
+             * Component representing a sin operation with input x and output y, where y = sin(x).
+             *
+             * The delta of y is the same as the delta of x.
+             *
+             * Input:  x ... field element
+             * Output: y ... sin(x) (field element)
+             * Constant: two_pi ... 2*pi (field element)
+             */
+            template<typename ArithmetizationType, typename FieldType, typename NonNativePolicyType>
+            class fix_sin;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams, typename NonNativePolicyType>
+            class fix_sin<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                          BlueprintFieldType, NonNativePolicyType>
+                : public plonk_component<BlueprintFieldType, ArithmetizationParams, 1, 0> {
+
+            public:
+                using rem_component =
+                    fix_rem<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                            BlueprintFieldType, basic_non_native_policy<BlueprintFieldType>>;
+
+            private:
+                uint8_t m1;    // Pre-comma 16-bit limbs
+                uint8_t m2;    // Post-comma 16-bit limbs
+                rem_component rem;
+
+                static uint8_t M(uint8_t m) {
+                    if (m == 0 || m > 2) {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+                    return m;
+                }
+
+            public:
+                struct var_positions {
+                    CellPosition x, y, s_x, x0, q0, sin0, cos0, cos1, two_pi;
+                    typename rem_component::var_positions rem_pos;
+                    int64_t start_row, rem_row, sin_row;
+                };
+
+                var_positions get_var_pos(const int64_t start_row_index) const {
+
+                    // trace layout (7 + m2 * (2 + m2) col(s), 1 + rem_rows row(s))
+                    //              (10 if m2=1, 15 if m2=2 col(s))
+                    //
+                    // rem only exists if m1=2; rem_rows = 0 if m1=1
+                    // two_pi only exists if rem exists
+                    // t = 0 if m2 = 1
+                    // t = 3 if m2 = 2
+                    //
+                    //     |                                         witness                                         |
+                    //  r\c| 0 | 1 |  2  | 3  | .. | 3+m2|4+m2|..|4+m2+t| 5+m2+t| .. |5+2*m2+t | 6+2*m2+t | 7+2*m2+t |
+                    // +---+---+---+-----+----+----+-----+----+--+------+-------+----+---------+----------+----------+
+                    // |rem| <rem_witness>                                                                           |
+                    // |sin| x | y | s_x | x0 | .. | xm2 | q0 |..|  qt  | sin0  | .. |  sinm2  |   cos0   |   cos1   |
+                    //
+                    //     | constant |
+                    //  r\c|    0     |
+                    // +---+----------+
+                    // |rem|  two_pi  |
+
+                    auto m1 = this->m1;
+                    auto m2 = this->m2;
+                    auto t = m2 * m2 - 1;
+                    var_positions pos;
+
+                    pos.start_row = start_row_index;
+                    pos.rem_row = pos.start_row;
+                    pos.sin_row = pos.rem_row;
+
+                    if (m1 == 2) {
+                        pos.sin_row += rem.rows_amount;
+                        pos.rem_pos = rem.get_var_pos(pos.rem_row);
+                        pos.two_pi = CellPosition(this->C(0), pos.rem_row);
+                    }
+
+                    pos.x = CellPosition(this->W(0), pos.sin_row);
+                    pos.y = CellPosition(this->W(1), pos.sin_row);
+                    pos.s_x = CellPosition(this->W(2), pos.sin_row);
+                    pos.x0 = CellPosition(this->W(3 + 0 * (m2 + 1)), pos.sin_row);    // occupies m2 + 1 cells
+                    pos.q0 = CellPosition(this->W(3 + 1 * (m2 + 1)), pos.sin_row);    // occupies t+1 cells
+                    pos.sin0 = CellPosition(this->W(5 + m2 + t), pos.sin_row);        // occupies m2 + 1 cells
+                    pos.cos0 = CellPosition(this->W(6 + 2 * m2 + t), pos.sin_row);
+                    pos.cos1 = CellPosition(this->W(7 + 2 * m2 + t), pos.sin_row);
+                    return pos;
+                }
+
+            private:
+                rem_component instantiate_rem() const {
+                    auto m1 = this->m1;
+                    auto m2 = this->m2;
+                    std::vector<std::uint32_t> witness_list;
+                    auto witness_columns = rem_component::get_witness_columns(this->witness_amount(), m1, m2);
+                    BLUEPRINT_RELEASE_ASSERT(this->witness_amount() >= witness_columns);
+                    witness_list.reserve(witness_columns);
+                    for (auto i = 0; i < witness_columns; i++) {
+                        witness_list.push_back(this->W(i));
+                    }
+                    // if m1=1: a rem_component is constructed but never used.
+                    return rem_component(witness_list, std::array<std::uint32_t, 0>(), std::array<std::uint32_t, 0>(),
+                                         m1, m2);
+                }
+
+            public:
+                const rem_component &get_rem_component() const {
+                    return rem;
+                }
+
+                uint64_t get_delta() const {
+                    return 1ULL << (16 * this->m2);
+                }
+
+                uint8_t get_m2() const {
+                    BLUEPRINT_RELEASE_ASSERT(this->m2 == rem.get_m2());
+                    return this->m2;
+                }
+
+                uint8_t get_m1() const {
+                    return this->m1;
+                }
+
+                uint8_t get_m() const {
+                    return this->m1 + this->m2;
+                }
+
+                constexpr static std::size_t get_witness_columns(uint8_t m2) {
+                    return M(m2) == 1 ? 10 : 15;
+                }
+
+                using component_type = plonk_component<BlueprintFieldType, ArithmetizationParams, 1, 0>;
+
+                using var = typename component_type::var;
+                using value_type = typename BlueprintFieldType::value_type;
+                using manifest_type = plonk_component_manifest;
+
+                value_type two_pi;
+
+                class gate_manifest_type : public component_gate_manifest {
+                public:
+                    std::uint32_t gates_amount() const override {
+                        return fix_sin::gates_amount;
+                    }
+                };
+
+                static gate_manifest get_gate_manifest(std::size_t witness_amount, std::size_t lookup_column_amount) {
+                    static gate_manifest manifest = gate_manifest(gate_manifest_type());
+                    return manifest;
+                }
+
+                // TACEO_TODO Update to lookup tables
+                static manifest_type get_manifest(uint8_t m2) {
+                    static manifest_type manifest = manifest_type(
+                        std::shared_ptr<manifest_param>(new manifest_single_value_param(get_witness_columns(m2))),
+                        true);
+                    return manifest;
+                }
+
+                constexpr static std::size_t get_rows_amount(uint8_t m1, uint8_t m2) {
+                    return M(m1) == 2 ? 1 + rem_component::get_rows_amount(get_witness_columns(m2), 0, m1, m2) : 1;
+                }
+
+                constexpr static value_type get_two_pi(uint8_t m2) {
+                    return M(m2) == 1 ? value_type(411775ULL) : value_type(26986075409ULL);
+                }
+
+                constexpr static const std::size_t gates_amount = 2;
+                const std::size_t rows_amount = get_rows_amount(this->m1, this->m2);
+
+                struct input_type {
+                    var x = var(0, 0, false);
+
+                    std::vector<var> all_vars() const {
+                        return {x};
+                    }
+                };
+
+                struct result_type {
+                    var output = var(0, 0, false);
+                    result_type(const fix_sin &component, std::uint32_t start_row_index) {
+                        const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                        output = var(magic(var_pos.y), false);
+                    }
+
+                    result_type(const fix_sin &component, std::size_t start_row_index) {
+                        const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                        output = var(magic(var_pos.y), false);
+                    }
+
+                    std::vector<var> all_vars() const {
+                        return {output};
+                    }
+                };
+
+                template<typename ContainerType>
+                explicit fix_sin(ContainerType witness, uint8_t m1, uint8_t m2) :
+                    component_type(witness, {}, {}, get_manifest(m2)), m1(M(m1)), m2(M(m2)), rem(instantiate_rem()),
+                    two_pi(get_two_pi(m2)) {};
+
+                template<typename WitnessContainerType, typename ConstantContainerType,
+                         typename PublicInputContainerType>
+                fix_sin(WitnessContainerType witness, ConstantContainerType constant,
+                        PublicInputContainerType public_input, uint8_t m1, uint8_t m2) :
+                    component_type(witness, constant, public_input, get_manifest(m2)),
+                    m1(M(m1)), m2(M(m2)), rem(instantiate_rem()), two_pi(get_two_pi(m2)) {};
+
+                fix_sin(std::initializer_list<typename component_type::witness_container_type::value_type> witnesses,
+                        std::initializer_list<typename component_type::constant_container_type::value_type> constants,
+                        std::initializer_list<typename component_type::public_input_container_type::value_type>
+                            public_inputs,
+                        uint8_t m1, uint8_t m2) :
+                    component_type(witnesses, constants, public_inputs, get_manifest(m2)),
+                    m1(M(m1)), m2(M(m2)), rem(instantiate_rem()), two_pi(get_two_pi(m2)) {};
+            };
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            using plonk_fixedpoint_sin =
+                fix_sin<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                        BlueprintFieldType, basic_non_native_policy<BlueprintFieldType>>;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::result_type generate_assignments(
+                const plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams> &component,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::input_type
+                    instance_input,
+                const std::uint32_t start_row_index) {
+
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                using var = typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::var;
+                using value_type = typename BlueprintFieldType::value_type;
+
+                auto m1 = component.get_m1();
+                auto m2 = component.get_m2();
+                auto m = component.get_m();
+
+                auto one = value_type::one();
+                auto zero = value_type::zero();
+                auto delta = value_type(component.get_delta());
+
+                auto x_val = var_value(assignment, instance_input.x);
+                assignment.witness(magic(var_pos.x)) = x_val;
+                std::vector<uint16_t> x0_val;
+                auto x_reduced_val = x_val;    // x_reduced guarantees the use of only one pre-comma limb
+                if (m1 == 2) {                 // if two pre-comma limbs are used, x is reduced mod 2*pi
+                    assignment.constant(magic(var_pos.two_pi)) = component.two_pi;
+                    auto rem_component = component.get_rem_component();
+                    typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::rem_component::input_type
+                        rem_input;
+                    rem_input.x = var(magic(var_pos.x));
+                    rem_input.y = var(magic(var_pos.two_pi), true, var::column_type::constant);
+                    auto rem_result = generate_assignments(rem_component, assignment, rem_input, var_pos.rem_row);
+                    x_reduced_val = var_value(assignment, rem_result.output);
+                }
+                bool sign = FixedPointHelper<BlueprintFieldType>::decompose(x_reduced_val, x0_val);
+                if (m1 == 2) {
+                    BLUEPRINT_RELEASE_ASSERT(!sign);
+                }
+                auto s_x_val = sign ? -one : one;
+                BLUEPRINT_RELEASE_ASSERT(x0_val.size() >= (m2 + 1));
+                assignment.witness(magic(var_pos.s_x)) = s_x_val;
+                for (size_t i = 0; i < m2 + 1; i++) {
+                    assignment.witness(var_pos.x0.column() + i, var_pos.x0.row()) = x0_val[i];
+                }
+
+                auto sin_a_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_sin_a_16() :
+                                             FixedPointTables<BlueprintFieldType>::get_sin_a_32();
+                auto sin_b_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_sin_b_16() :
+                                             FixedPointTables<BlueprintFieldType>::get_sin_b_32();
+                auto cos_a_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_cos_a_16() :
+                                             FixedPointTables<BlueprintFieldType>::get_cos_a_32();
+                auto cos_b_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_cos_b_16() :
+                                             FixedPointTables<BlueprintFieldType>::get_cos_b_32();
+                auto sin_c_table = FixedPointTables<BlueprintFieldType>::get_sin_c_32();
+
+                auto sin0_val = sin_a_table[x0_val[m2 - 0]];
+                auto sin1_val = sin_b_table[x0_val[m2 - 1]];
+                auto sin2_val = m2 == 1 ? zero : sin_c_table[x0_val[m2 - 2]];
+                auto cos0_val = cos_a_table[x0_val[m2 - 0]];
+                auto cos1_val = cos_b_table[x0_val[m2 - 1]];
+                auto cos2_val = delta;
+
+                assignment.witness(magic(var_pos.sin0)) = sin0_val;
+                assignment.witness(var_pos.sin0.column() + 1, var_pos.sin0.row()) = sin1_val;
+                if (m2 == 2) {
+                    assignment.witness(var_pos.sin0.column() + 2, var_pos.sin0.row()) = sin2_val;
+                }
+                assignment.witness(magic(var_pos.cos0)) = cos0_val;
+                assignment.witness(magic(var_pos.cos1)) = cos1_val;
+
+                // sin(-a)    = -sin(a)
+                // sin(a+b)   = sin(a)cos(b) + cos(a)sin(b)
+                // sin(a+b+c) = sin(a+b)cos(c) + cos(a+b)sin(c)
+                //            = cos(c) * (sin(a)cos(b) + cos(a)sin(b))
+                //            + sin(c) * (cos(a)cos(b) - sin(a)sin(b))
+                value_type computation = m2 == 1 ? s_x_val * (sin0_val * cos1_val + cos0_val * sin1_val) :
+                                                   s_x_val * (cos2_val * (sin0_val * cos1_val + cos0_val * sin1_val) +
+                                                              sin2_val * (cos0_val * cos1_val - sin0_val * sin1_val));
+
+                auto actual_delta = m2 == 1 ? delta : delta * delta;
+
+                auto tmp = FixedPointHelper<BlueprintFieldType>::round_div_mod(computation, actual_delta);
+                auto y_val = tmp.quotient;
+                auto q_val = tmp.remainder;
+
+                assignment.witness(magic(var_pos.y)) = y_val;
+
+                if (m2 == 1) {
+                    assignment.witness(magic(var_pos.q0)) = q_val;
+                } else {    // m2 == 2
+                    std::vector<uint16_t> q0_val;
+                    bool sign_ = FixedPointHelper<BlueprintFieldType>::decompose(q_val, q0_val);
+                    BLUEPRINT_RELEASE_ASSERT(!sign_);
+                    BLUEPRINT_RELEASE_ASSERT(q0_val.size() >= (4));
+                    for (size_t i = 0; i < 4; i++) {
+                        assignment.witness(var_pos.q0.column() + i, var_pos.q0.row()) = q0_val[i];
+                    }
+                }
+
+                return typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::vector<crypto3::zk::snark::plonk_constraint<BlueprintFieldType>> get_constraints(
+                const plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+
+                using var = typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::var;
+                auto m1 = component.get_m1();
+                auto m2 = component.get_m2();
+                auto m = component.get_m();
+
+                auto delta = typename BlueprintFieldType::value_type(component.get_delta());
+                auto x = var(magic(var_pos.x));
+                auto s_x = var(magic(var_pos.s_x));
+                auto x0 = nil::crypto3::math::expression(var(magic(var_pos.x0)));
+
+                // decomposition of x
+                for (size_t i = 1; i < m2 + 1; i++) {
+                    x0 += var(var_pos.x0.column() + i, var_pos.x0.row()) * (1ULL << (16 * i));
+                }
+                auto x_reduced = x;
+                if (m1 == 2) {
+                    typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::rem_component::result_type
+                        rem_out(component.get_rem_component(), static_cast<uint32_t>(var_pos.rem_row));
+                    x_reduced = var(rem_out.output);
+                }
+                auto constraint_1 = x_reduced - s_x * x0;
+
+                // sign of x
+                auto constraint_2 = (s_x - 1) * (s_x + 1);
+
+                auto y = var(magic(var_pos.y));
+                auto sin0 = var(magic(var_pos.sin0));
+                auto sin1 = var(var_pos.sin0.column() + 1, var_pos.sin0.row());
+                auto cos0 = var(magic(var_pos.cos0));
+                auto cos1 = var(magic(var_pos.cos1));
+                auto sin2 = var(var_pos.sin0.column() + 2, var_pos.sin0.row());
+                auto cos2 = delta;
+                auto q = nil::crypto3::math::expression(var(magic(var_pos.q0)));
+                for (size_t i = 1; i < m2 * m2; i++) {
+                    q += var(var_pos.q0.column() + i, var_pos.q0.row()) * (1ULL << (16 * i));
+                }
+
+                auto computation = m2 == 1 ?
+                                       s_x * (sin0 * cos1 + cos0 * sin1) :
+                                       s_x * (cos2 * (sin0 * cos1 + cos0 * sin1) + sin2 * (cos0 * cos1 - sin0 * sin1));
+                auto actual_delta = m2 == 1 ? delta : delta * delta;
+
+                auto constraint_3 = 2 * (computation - y * actual_delta - q) + actual_delta;    // "custom" rescale
+
+                // TACEO_TODO extend for lookup constraint for x0, q0, sin0, cos0
+                return {constraint_1, constraint_2, constraint_3};
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_gates(
+                const plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+
+                auto constraints = get_constraints(component, bp, assignment, instance_input);
+                return bp.add_gate(constraints);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            void generate_copy_constraints(
+                const plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input,
+                const std::size_t start_row_index) {
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                using var = typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::var;
+                var x = var(magic(var_pos.x), false);
+                bp.add_copy_constraint({instance_input.x, x});
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::result_type generate_circuit(
+                const plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input,
+                const std::size_t start_row_index) {
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                if (component.get_m1() == 2) {    // if m1=2, rem exists
+                    typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::rem_component::input_type
+                        rem_input;
+
+                    using var = typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::var;
+
+                    rem_input.x = var(magic(var_pos.x), false);
+                    rem_input.y = var(magic(var_pos.two_pi), false, var::column_type::constant);
+
+                    generate_circuit(component.get_rem_component(), bp, assignment, rem_input, var_pos.rem_row);
+                }
+
+                // TACEO_TODO extend for lookup?
+                std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
+
+                assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
+
+                generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
+
+                return typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_SIN_HPP

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
@@ -167,7 +167,6 @@ namespace nil {
                     return manifest;
                 }
 
-                // TACEO_TODO Update to lookup tables
                 static manifest_type get_manifest(uint8_t m2) {
                     static manifest_type manifest = manifest_type(
                         std::shared_ptr<manifest_param>(new manifest_single_value_param(get_witness_columns(m2))),
@@ -175,7 +174,8 @@ namespace nil {
                     return manifest;
                 }
 
-                constexpr static std::size_t get_rows_amount(uint8_t m1, uint8_t m2) {
+                constexpr static std::size_t get_rows_amount(std::size_t witness_amount,
+                                                             std::size_t lookup_column_amount, uint8_t m1, uint8_t m2) {
                     return M(m1) == 2 ? 1 + rem_component::get_rows_amount(get_witness_columns(m2), 0, m1, m2) : 1;
                 }
 
@@ -184,7 +184,7 @@ namespace nil {
                 }
 
                 constexpr static const std::size_t gates_amount = 2;
-                const std::size_t rows_amount = get_rows_amount(this->m1, this->m2);
+                const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, this->m1, this->m2);
 
                 struct input_type {
                     var x = var(0, 0, false);
@@ -454,7 +454,6 @@ namespace nil {
 
                 auto constraint_3 = 2 * (computation - y * actual_delta - q) + actual_delta;    // "custom" rescale
 
-                // TACEO_TODO extend for lookup constraint for x0, q0, sin0, cos0
                 return {constraint_1, constraint_2, constraint_3};
             }
 
@@ -608,7 +607,6 @@ namespace nil {
                     generate_circuit(component.get_rem_component(), bp, assignment, rem_input, var_pos.rem_row);
                 }
 
-                // TACEO_TODO extend for lookup?
                 std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
 
                 assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
@@ -344,12 +344,15 @@ namespace nil {
                                              FixedPointTables<BlueprintFieldType>::get_cos_b_32();
                 auto sin_c_table = FixedPointTables<BlueprintFieldType>::get_sin_c_32();
 
-                auto sin0_val = sin_a_table[x0_val[m2 - 0]];
-                auto sin1_val = sin_b_table[x0_val[m2 - 1]];
-                auto sin2_val = m2 == 1 ? zero : sin_c_table[x0_val[m2 - 2]];
-                auto cos0_val = cos_a_table[x0_val[m2 - 0]];
-                auto cos1_val = cos_b_table[x0_val[m2 - 1]];
-                auto cos2_val = delta;
+                // x0 .. smallest limb, x1 .. 2nd smallest limb, x2 .. 3rd smallest limb (2 or 3 limbs in total)
+                // sin0 holds the looked-up value of the one and only pre-comma limb, so sin(a) = sin0 where a is the
+                // largest limb of the input. a = x0_val[m2], ..
+                auto sin0_val = sin_a_table[x0_val[m2 - 0]];                     // 0 .. a
+                auto sin1_val = sin_b_table[x0_val[m2 - 1]];                     // 1 .. b
+                auto sin2_val = m2 == 1 ? zero : sin_c_table[x0_val[m2 - 2]];    // 2 .. c
+                auto cos0_val = cos_a_table[x0_val[m2 - 0]];                     // 0 .. a
+                auto cos1_val = cos_b_table[x0_val[m2 - 1]];                     // 1 .. b
+                auto cos2_val = delta;                                           // 2 .. c
 
                 assignment.witness(splat(var_pos.sin0)) = sin0_val;
                 assignment.witness(var_pos.sin0.column() + 1, var_pos.sin0.row()) = sin1_val;
@@ -364,6 +367,8 @@ namespace nil {
                 // sin(a+b+c) = sin(a+b)cos(c) + cos(a+b)sin(c)
                 //            = cos(c) * (sin(a)cos(b) + cos(a)sin(b))
                 //            + sin(c) * (cos(a)cos(b) - sin(a)sin(b))
+                // sin(a) .. sin0, sin(b) .. sin1, sin(c) .. sin2
+                // cos(a) .. cos0, cos(b) .. cos1, cos(c) .. cos2
                 value_type computation = m2 == 1 ? s_x_val * (sin0_val * cos1_val + cos0_val * sin1_val) :
                                                    s_x_val * (cos2_val * (sin0_val * cos1_val + cos0_val * sin1_val) +
                                                               sin2_val * (cos0_val * cos1_val - sin0_val * sin1_val));
@@ -429,17 +434,19 @@ namespace nil {
                 auto constraint_2 = (s_x - 1) * (s_x + 1);
 
                 auto y = var(splat(var_pos.y));
-                auto sin0 = var(splat(var_pos.sin0));
-                auto sin1 = var(var_pos.sin0.column() + 1, var_pos.sin0.row());
-                auto cos0 = var(splat(var_pos.cos0));
-                auto cos1 = var(splat(var_pos.cos1));
-                auto sin2 = var(var_pos.sin0.column() + 2, var_pos.sin0.row());
-                auto cos2 = delta;
+                auto sin0 = var(splat(var_pos.sin0));                              // 0 .. a
+                auto sin1 = var(var_pos.sin0.column() + 1, var_pos.sin0.row());    // 1 .. b
+                auto cos0 = var(splat(var_pos.cos0));                              // 0 .. a
+                auto cos1 = var(splat(var_pos.cos1));                              // 1 .. b
+                auto sin2 = var(var_pos.sin0.column() + 2, var_pos.sin0.row());    // 2 .. c
+                auto cos2 = delta;                                                 // 2 .. c
                 auto q = nil::crypto3::math::expression(var(splat(var_pos.q0)));
                 for (size_t i = 1; i < m2 * m2; i++) {
                     q += var(var_pos.q0.column() + i, var_pos.q0.row()) * (1ULL << (16 * i));
                 }
 
+                // sin(a) .. sin0, sin(b) .. sin1, sin(c) .. sin2
+                // cos(a) .. cos0, cos(b) .. cos1, cos(c) .. cos2
                 auto computation = m2 == 1 ?
                                        s_x * (sin0 * cos1 + cos0 * sin1) :
                                        s_x * (cos2 * (sin0 * cos1 + cos0 * sin1) + sin2 * (cos0 * cos1 - sin0 * sin1));
@@ -533,6 +540,9 @@ namespace nil {
                 }
 
                 // lookup sin, cos
+                // x0 .. smallest limb, x1 .. 2nd smallest limb, x2 .. 3rd smallest limb (2 or 3 limbs in total)
+                // sin0 holds the looked-up value of the one and only pre-comma limb, so sin(a) = sin0 where a is the
+                // largest limb of the input. a = x0_val[m2], ..
                 auto x0 = var(var_pos.x0.column() + m2 - 0, var_pos.x0.row());
                 auto x1 = var(var_pos.x0.column() + m2 - 1, var_pos.x0.row());
                 auto x2 = var(var_pos.x0.column() + m2 - 2, var_pos.x0.row());    // invalid if m2 == 1

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
@@ -533,12 +533,12 @@ namespace nil {
                 }
 
                 // lookup sin, cos
-                auto x0 = var(var_pos.x0.column() + 0, var_pos.x0.row());
-                auto x1 = var(var_pos.x0.column() + 1, var_pos.x0.row());
-                auto x2 = var(var_pos.x0.column() + 2, var_pos.x0.row());
-                auto sin0 = var(var_pos.sin0.column() + 0, var_pos.sin0.row());
-                auto sin1 = var(var_pos.sin0.column() + 1, var_pos.sin0.row());
-                auto sin2 = var(var_pos.sin0.column() + 2, var_pos.sin0.row());
+                auto x0 = var(var_pos.x0.column() + m2 - 0, var_pos.x0.row());
+                auto x1 = var(var_pos.x0.column() + m2 - 1, var_pos.x0.row());
+                auto x2 = var(var_pos.x0.column() + m2 - 2, var_pos.x0.row());    // invalid if m2 == 1
+                auto sin0 = var(var_pos.sin0.column() + m2 - 0, var_pos.sin0.row());
+                auto sin1 = var(var_pos.sin0.column() + m2 - 1, var_pos.sin0.row());
+                auto sin2 = var(var_pos.sin0.column() + m2 - 2, var_pos.sin0.row());    // invalid if m2 == 1
                 {
                     constraint_type constraint;
                     constraint.table_id = sin_a_table_id;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
@@ -536,9 +536,9 @@ namespace nil {
                 auto x0 = var(var_pos.x0.column() + m2 - 0, var_pos.x0.row());
                 auto x1 = var(var_pos.x0.column() + m2 - 1, var_pos.x0.row());
                 auto x2 = var(var_pos.x0.column() + m2 - 2, var_pos.x0.row());    // invalid if m2 == 1
-                auto sin0 = var(var_pos.sin0.column() + m2 - 0, var_pos.sin0.row());
-                auto sin1 = var(var_pos.sin0.column() + m2 - 1, var_pos.sin0.row());
-                auto sin2 = var(var_pos.sin0.column() + m2 - 2, var_pos.sin0.row());    // invalid if m2 == 1
+                auto sin0 = var(var_pos.sin0.column() + 0, var_pos.sin0.row());
+                auto sin1 = var(var_pos.sin0.column() + 1, var_pos.sin0.row());
+                auto sin2 = var(var_pos.sin0.column() + 2, var_pos.sin0.row());    // invalid if m2 == 1
                 {
                     constraint_type constraint;
                     constraint.table_id = sin_a_table_id;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp
@@ -2,6 +2,7 @@
 #define CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_SIN_HPP
 
 #include "nil/blueprint/components/algebra/fixedpoint/plonk/rem.hpp"
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/trigonometric.hpp"
 
 namespace nil {
     namespace blueprint {
@@ -148,6 +149,9 @@ namespace nil {
                 using var = typename component_type::var;
                 using value_type = typename BlueprintFieldType::value_type;
                 using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using range_table = fixedpoint_range_table<BlueprintFieldType>;
 
                 value_type two_pi;
 
@@ -206,6 +210,57 @@ namespace nil {
                         return {output};
                     }
                 };
+
+// Allows disabling lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result = rem.component_custom_lookup_tables();
+
+                    if (m2 == 1) {
+                        auto table = std::shared_ptr<lookup_table_definition>(
+                            new fixedpoint_trigon_16_table<BlueprintFieldType>());
+                        result.push_back(table);
+                    } else if (m2 == 2) {
+                        auto table = std::shared_ptr<lookup_table_definition>(
+                            new fixedpoint_trigon_32_table<BlueprintFieldType>());
+                        result.push_back(table);
+                    } else {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables = rem.component_lookup_tables();
+
+                    if (m2 == 1) {
+                        lookup_tables[fixedpoint_trigon_16_table<BlueprintFieldType>::FULL_SIN_A] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_trigon_16_table<BlueprintFieldType>::FULL_SIN_B] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_trigon_16_table<BlueprintFieldType>::FULL_COS_A] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_trigon_16_table<BlueprintFieldType>::FULL_COS_B] =
+                            0;    // REQUIRED_TABLE
+                    } else if (m2 == 2) {
+                        lookup_tables[fixedpoint_trigon_32_table<BlueprintFieldType>::FULL_SIN_A] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_trigon_32_table<BlueprintFieldType>::FULL_SIN_B] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_trigon_32_table<BlueprintFieldType>::FULL_SIN_C] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_trigon_32_table<BlueprintFieldType>::FULL_COS_A] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_trigon_32_table<BlueprintFieldType>::FULL_COS_B] =
+                            0;    // REQUIRED_TABLE
+                    } else {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+
+                    return lookup_tables;
+                }
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
 
                 template<typename ContainerType>
                 explicit fix_sin(ContainerType witness, uint8_t m1, uint8_t m2) :
@@ -425,6 +480,102 @@ namespace nil {
             }
 
             template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m2 = component.get_m2();
+
+                const std::map<std::string, std::size_t> &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+                using range_table =
+                    typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::range_table;
+
+                auto range_table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
+                auto sin_a_table_id =
+                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_trigon_16_table<BlueprintFieldType>::FULL_SIN_A) :
+                              lookup_tables_indices.at(fixedpoint_trigon_32_table<BlueprintFieldType>::FULL_SIN_A);
+                auto sin_b_table_id =
+                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_trigon_16_table<BlueprintFieldType>::FULL_SIN_B) :
+                              lookup_tables_indices.at(fixedpoint_trigon_32_table<BlueprintFieldType>::FULL_SIN_B);
+                auto cos_a_table_id =
+                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_trigon_16_table<BlueprintFieldType>::FULL_COS_A) :
+                              lookup_tables_indices.at(fixedpoint_trigon_32_table<BlueprintFieldType>::FULL_COS_A);
+                auto cos_b_table_id =
+                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_trigon_16_table<BlueprintFieldType>::FULL_COS_B) :
+                              lookup_tables_indices.at(fixedpoint_trigon_32_table<BlueprintFieldType>::FULL_COS_B);
+
+                std::vector<constraint_type> constraints;
+
+                // lookup decomposition of x
+                for (size_t i = 0; i < m2 + 1; i++) {
+                    constraint_type constraint;
+                    constraint.table_id = range_table_id;
+                    auto xi = var(var_pos.x0.column() + i, var_pos.x0.row());
+                    constraint.lookup_input = {xi};
+                    constraints.push_back(constraint);
+                }
+
+                // lookup decomposition of q
+                for (size_t i = 0; i < m2 * m2; i++) {
+                    constraint_type constraint;
+                    constraint.table_id = range_table_id;
+                    auto qi = var(var_pos.q0.column() + i, var_pos.q0.row());
+                    constraint.lookup_input = {qi};
+                    constraints.push_back(constraint);
+                }
+
+                // lookup sin, cos
+                auto x0 = var(var_pos.x0.column() + 0, var_pos.x0.row());
+                auto x1 = var(var_pos.x0.column() + 1, var_pos.x0.row());
+                auto x2 = var(var_pos.x0.column() + 2, var_pos.x0.row());
+                auto sin0 = var(var_pos.sin0.column() + 0, var_pos.sin0.row());
+                auto sin1 = var(var_pos.sin0.column() + 1, var_pos.sin0.row());
+                auto sin2 = var(var_pos.sin0.column() + 2, var_pos.sin0.row());
+                {
+                    constraint_type constraint;
+                    constraint.table_id = sin_a_table_id;
+                    constraint.lookup_input = {x0, sin0};
+                    constraints.push_back(constraint);
+                }
+                {
+                    constraint_type constraint;
+                    constraint.table_id = cos_a_table_id;
+                    constraint.lookup_input = {x0, var(splat(var_pos.cos0))};
+                    constraints.push_back(constraint);
+                }
+                {
+                    constraint_type constraint;
+                    constraint.table_id = sin_b_table_id;
+                    constraint.lookup_input = {x1, sin1};
+                    constraints.push_back(constraint);
+                }
+                {
+                    constraint_type constraint;
+                    constraint.table_id = cos_b_table_id;
+                    constraint.lookup_input = {x1, var(splat(var_pos.cos1))};
+                    constraints.push_back(constraint);
+                }
+                if (m2 == 2) {
+                    constraint_type constraint;
+                    auto sin_c_table_id =
+                        lookup_tables_indices.at(fixedpoint_trigon_32_table<BlueprintFieldType>::FULL_SIN_C);
+                    constraint.table_id = sin_c_table_id;
+                    constraint.lookup_input = {x2, sin2};
+                    constraints.push_back(constraint);
+                }
+
+                return bp.add_lookup_gate(constraints);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
             typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::result_type generate_circuit(
                 const plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams> &component,
                 circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
@@ -451,6 +602,11 @@ namespace nil {
 
                 assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
 
+// Allows disabling lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, start_row_index + component.rows_amount - 1);
+#endif
                 generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
 
                 return typename plonk_fixedpoint_sin<BlueprintFieldType, ArithmetizationParams>::result_type(

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/sqrt.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/sqrt.hpp
@@ -10,6 +10,7 @@
 #include <nil/blueprint/basic_non_native_policy.hpp>
 
 #include "nil/blueprint/components/algebra/fixedpoint/type.hpp"
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp"
 
 namespace nil {
     namespace blueprint {
@@ -66,6 +67,9 @@ namespace nil {
 
                 using var = typename component_type::var;
                 using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using range_table = fixedpoint_range_table<BlueprintFieldType>;
 
                 class gate_manifest_type : public component_gate_manifest {
                 public:
@@ -79,11 +83,10 @@ namespace nil {
                     return manifest;
                 }
 
-                // TACEO_TODO Update to lookup tables
                 static manifest_type get_manifest(uint8_t m1, uint8_t m2) {
                     static manifest_type manifest =
-                        manifest_type(std::shared_ptr<manifest_param>(new manifest_range_param(
-                                          2 + 2 * (M(m2) + M(m1)), 4 + 4 * (m2 + m1))),
+                        manifest_type(std::shared_ptr<manifest_param>(
+                                          new manifest_range_param(2 + 2 * (M(m2) + M(m1)), 4 + 4 * (m2 + m1))),
                                       false);
                     return manifest;
                 }
@@ -97,7 +100,8 @@ namespace nil {
                     }
                 }
 
-                constexpr static const std::size_t gates_amount = 1;
+                // Includes the constraints + lookup_gates
+                constexpr static const std::size_t gates_amount = 2;
                 const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, m1, m2);
 
                 struct input_type {
@@ -174,6 +178,22 @@ namespace nil {
                         return {output};
                     }
                 };
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result = {};
+                    auto table = std::shared_ptr<lookup_table_definition>(new range_table());
+                    result.push_back(table);
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    return lookup_tables;
+                }
+#endif
 
                 template<typename ContainerType>
                 explicit fix_sqrt(ContainerType witness, uint8_t m1, uint8_t m2) :
@@ -292,7 +312,6 @@ namespace nil {
                 auto y_sq = var(magic(var_pos.y_sq));
                 auto r = var(magic(var_pos.r));
 
-                // TACEO_TODO extend for lookup constraint
                 auto constraint_1 = r * (r - 1);
                 auto constraint_2 = y - y0;
                 auto constraint_3 = (x - y_sq) + 2 * r * y - r - a0;
@@ -300,6 +319,71 @@ namespace nil {
                 auto constraint_5 = 2 * r * (x - y_sq) + y_sq + y - x - r - c0;
 
                 return bp.add_gate({constraint_1, constraint_2, constraint_3, constraint_4, constraint_5});
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_fixedpoint_sqrt<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_sqrt<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m = component.get_m();
+
+                const std::map<std::string, std::size_t> &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_fixedpoint_sqrt<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+                using range_table =
+                    typename plonk_fixedpoint_sqrt<BlueprintFieldType, ArithmetizationParams>::range_table;
+
+                std::vector<constraint_type> constraints;
+
+                auto table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
+                if (component.rows_amount == 2) {
+                    constraints.reserve(2 * m);
+                    // We put just two decompositions into the constraint and activate it twice
+                    BLUEPRINT_RELEASE_ASSERT(var_pos.y0.row() == var_pos.a0.row());
+                    BLUEPRINT_RELEASE_ASSERT(var_pos.b0.row() == var_pos.c0.row());
+                    BLUEPRINT_RELEASE_ASSERT(var_pos.a0.column() == var_pos.c0.column());
+                    BLUEPRINT_RELEASE_ASSERT(var_pos.b0.column() == var_pos.y0.column());
+                } else {
+                    constraints.reserve(4 * m);
+                }
+
+                for (auto i = 0; i < m; i++) {
+                    constraint_type constraint_y, constraint_a;
+                    constraint_y.table_id = table_id;
+                    constraint_a.table_id = table_id;
+
+                    // We put row=0 here and enable the selector in the correct one
+                    auto yi = var(var_pos.y0.column() + i, 0);
+                    auto ai = var(var_pos.a0.column() + i, 0);
+                    constraint_y.lookup_input = {yi};
+                    constraint_a.lookup_input = {ai};
+
+                    constraints.push_back(constraint_y);
+                    constraints.push_back(constraint_a);
+
+                    if (component.rows_amount == 1) {
+                        constraint_type constraint_b, constraint_c;
+                        constraint_b.table_id = table_id;
+                        constraint_c.table_id = table_id;
+
+                        auto bi = var(var_pos.b0.column() + i, 0);
+                        auto ci = var(var_pos.c0.column() + i, 0);
+                        constraint_b.lookup_input = {bi};
+                        constraint_c.lookup_input = {ci};
+
+                        constraints.push_back(constraint_b);
+                        constraints.push_back(constraint_c);
+                    }
+                }
+
+                return bp.add_lookup_gate(constraints);
             }
 
             template<typename BlueprintFieldType, typename ArithmetizationParams>
@@ -330,11 +414,20 @@ namespace nil {
                     &instance_input,
                 const std::size_t start_row_index) {
 
-                // TACEO_TODO extend for lookup?
                 std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
 
                 // selector goes onto last row and gate uses all rows
                 assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, start_row_index);
+                if (component.rows_amount == 2) {
+                    // We put just two decompositions into the constraint and activate it twice
+                    assignment.enable_selector(lookup_selector_index, start_row_index + 1);
+                }
+#endif
 
                 generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/sqrt.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/sqrt.hpp
@@ -166,12 +166,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_sqrt &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     result_type(const fix_sqrt &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -240,10 +240,10 @@ namespace nil {
 
                 auto y_sq_val = y_val * y_val;
 
-                assignment.witness(magic(var_pos.x)) = x_val;
-                assignment.witness(magic(var_pos.y)) = y_val;
-                assignment.witness(magic(var_pos.y_sq)) = y_sq_val;
-                assignment.witness(magic(var_pos.r)) = r_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.y_sq)) = y_sq_val;
+                assignment.witness(splat(var_pos.r)) = r_val;
 
                 // Decompositions
                 auto a_val = (x_val_delta - y_sq_val) + r_val * (2 * y_val - 1);
@@ -296,10 +296,10 @@ namespace nil {
                 const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(start_row_index);
 
-                auto y0 = nil::crypto3::math::expression(var(magic(var_pos.y0)));
-                auto a0 = nil::crypto3::math::expression(var(magic(var_pos.a0)));
-                auto b0 = nil::crypto3::math::expression(var(magic(var_pos.b0)));
-                auto c0 = nil::crypto3::math::expression(var(magic(var_pos.c0)));
+                auto y0 = nil::crypto3::math::expression(var(splat(var_pos.y0)));
+                auto a0 = nil::crypto3::math::expression(var(splat(var_pos.a0)));
+                auto b0 = nil::crypto3::math::expression(var(splat(var_pos.b0)));
+                auto c0 = nil::crypto3::math::expression(var(splat(var_pos.c0)));
                 for (auto i = 1; i < m; i++) {
                     y0 += var(var_pos.y0.column() + i, var_pos.y0.row()) * (1ULL << (16 * i));
                     a0 += var(var_pos.a0.column() + i, var_pos.a0.row()) * (1ULL << (16 * i));
@@ -307,10 +307,10 @@ namespace nil {
                     c0 += var(var_pos.c0.column() + i, var_pos.c0.row()) * (1ULL << (16 * i));
                 }
 
-                auto x = var(magic(var_pos.x)) * component.get_delta();
-                auto y = var(magic(var_pos.y));
-                auto y_sq = var(magic(var_pos.y_sq));
-                auto r = var(magic(var_pos.r));
+                auto x = var(splat(var_pos.x)) * component.get_delta();
+                auto y = var(splat(var_pos.y));
+                auto y_sq = var(splat(var_pos.y_sq));
+                auto r = var(splat(var_pos.r));
 
                 auto constraint_1 = r * (r - 1);
                 auto constraint_2 = y - y0;
@@ -400,7 +400,7 @@ namespace nil {
 
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
-                auto x = var(magic(var_pos.x));
+                auto x = var(splat(var_pos.x));
                 bp.add_copy_constraint({instance_input.x, x});
             }
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/sqrt_floor.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/sqrt_floor.hpp
@@ -333,10 +333,9 @@ namespace nil {
                     constraint_a.table_id = table_id;
                     constraint_b.table_id = table_id;
 
-                    // We put row=0 here and enable the selector in the correct one
-                    auto yi = var(var_pos.y0.column() + i, 0);
-                    auto ai = var(var_pos.a0.column() + i, 0);
-                    auto bi = var(var_pos.b0.column() + i, 0);
+                    auto yi = var(var_pos.y0.column() + i, var_pos.y0.row());
+                    auto ai = var(var_pos.a0.column() + i, var_pos.a0.row());
+                    auto bi = var(var_pos.b0.column() + i, var_pos.b0.row());
                     constraint_y.lookup_input = {yi};
                     constraint_a.lookup_input = {ai};
                     constraint_b.lookup_input = {bi};

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/sqrt_floor.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/sqrt_floor.hpp
@@ -163,12 +163,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_sqrt_floor &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     result_type(const fix_sqrt_floor &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -235,8 +235,8 @@ namespace nil {
 
                 auto y_sq_val = y_val * y_val;
 
-                assignment.witness(magic(var_pos.x)) = x_val;
-                assignment.witness(magic(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
 
                 // Decompositions
                 auto a_val = x_val_delta - y_sq_val;
@@ -283,17 +283,17 @@ namespace nil {
                 const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
                 const auto var_pos = component.get_var_pos(start_row_index);
 
-                auto y0 = nil::crypto3::math::expression(var(magic(var_pos.y0)));
-                auto a0 = nil::crypto3::math::expression(var(magic(var_pos.a0)));
-                auto b0 = nil::crypto3::math::expression(var(magic(var_pos.b0)));
+                auto y0 = nil::crypto3::math::expression(var(splat(var_pos.y0)));
+                auto a0 = nil::crypto3::math::expression(var(splat(var_pos.a0)));
+                auto b0 = nil::crypto3::math::expression(var(splat(var_pos.b0)));
                 for (auto i = 1; i < m; i++) {
                     y0 += var(var_pos.y0.column() + i, var_pos.y0.row()) * (1ULL << (16 * i));
                     a0 += var(var_pos.a0.column() + i, var_pos.a0.row()) * (1ULL << (16 * i));
                     b0 += var(var_pos.b0.column() + i, var_pos.b0.row()) * (1ULL << (16 * i));
                 }
 
-                auto x = var(magic(var_pos.x)) * component.get_delta();
-                auto y = var(magic(var_pos.y));
+                auto x = var(splat(var_pos.x)) * component.get_delta();
+                auto y = var(splat(var_pos.y));
 
                 auto constraint_1 = y - y0;
                 auto constraint_2 = (x - y * y) - a0;
@@ -362,7 +362,7 @@ namespace nil {
 
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
-                auto x = var(magic(var_pos.x));
+                auto x = var(splat(var_pos.x));
                 bp.add_copy_constraint({instance_input.x, x});
             }
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/sqrt_floor.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/sqrt_floor.hpp
@@ -10,6 +10,7 @@
 #include <nil/blueprint/basic_non_native_policy.hpp>
 
 #include "nil/blueprint/components/algebra/fixedpoint/type.hpp"
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp"
 
 namespace nil {
     namespace blueprint {
@@ -66,6 +67,9 @@ namespace nil {
 
                 using var = typename component_type::var;
                 using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using range_table = fixedpoint_range_table<BlueprintFieldType>;
 
                 class gate_manifest_type : public component_gate_manifest {
                 public:
@@ -79,11 +83,10 @@ namespace nil {
                     return manifest;
                 }
 
-                // TACEO_TODO Update to lookup tables
                 static manifest_type get_manifest(uint8_t m1, uint8_t m2) {
                     static manifest_type manifest =
-                        manifest_type(std::shared_ptr<manifest_param>(new manifest_range_param(
-                                          2 * (M(m2) + M(m1)), 2 + 3 * (m2 + m1))),
+                        manifest_type(std::shared_ptr<manifest_param>(
+                                          new manifest_range_param(2 * (M(m2) + M(m1)), 2 + 3 * (m2 + m1))),
                                       false);
                     return manifest;
                 }
@@ -97,7 +100,8 @@ namespace nil {
                     }
                 }
 
-                constexpr static const std::size_t gates_amount = 1;
+                // Includes the constraints + lookup_gates
+                constexpr static const std::size_t gates_amount = 2;
                 const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, m1, m2);
 
                 struct input_type {
@@ -171,6 +175,22 @@ namespace nil {
                         return {output};
                     }
                 };
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result = {};
+                    auto table = std::shared_ptr<lookup_table_definition>(new range_table());
+                    result.push_back(table);
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    return lookup_tables;
+                }
+#endif
 
                 template<typename ContainerType>
                 explicit fix_sqrt_floor(ContainerType witness, uint8_t m1, uint8_t m2) :
@@ -275,12 +295,58 @@ namespace nil {
                 auto x = var(magic(var_pos.x)) * component.get_delta();
                 auto y = var(magic(var_pos.y));
 
-                // TACEO_TODO extend for lookup constraint
                 auto constraint_1 = y - y0;
                 auto constraint_2 = (x - y * y) - a0;
                 auto constraint_3 = 2 * y - (x - y * y) - b0;
 
                 return bp.add_gate({constraint_1, constraint_2, constraint_3});
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_fixedpoint_sqrt_floor<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_sqrt_floor<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m = component.get_m();
+
+                const std::map<std::string, std::size_t> &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_fixedpoint_sqrt_floor<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+                using range_table =
+                    typename plonk_fixedpoint_sqrt_floor<BlueprintFieldType, ArithmetizationParams>::range_table;
+
+                std::vector<constraint_type> constraints;
+                constraints.reserve(3 * m);
+
+                auto table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
+
+                for (auto i = 0; i < m; i++) {
+                    constraint_type constraint_y, constraint_a, constraint_b;
+                    constraint_y.table_id = table_id;
+                    constraint_a.table_id = table_id;
+                    constraint_b.table_id = table_id;
+
+                    // We put row=0 here and enable the selector in the correct one
+                    auto yi = var(var_pos.y0.column() + i, 0);
+                    auto ai = var(var_pos.a0.column() + i, 0);
+                    auto bi = var(var_pos.b0.column() + i, 0);
+                    constraint_y.lookup_input = {yi};
+                    constraint_a.lookup_input = {ai};
+                    constraint_b.lookup_input = {bi};
+
+                    constraints.push_back(constraint_y);
+                    constraints.push_back(constraint_a);
+                    constraints.push_back(constraint_b);
+                }
+
+                return bp.add_lookup_gate(constraints);
             }
 
             template<typename BlueprintFieldType, typename ArithmetizationParams>
@@ -312,11 +378,18 @@ namespace nil {
                         &instance_input,
                     const std::size_t start_row_index) {
 
-                // TACEO_TODO extend for lookup?
+                auto last_row = start_row_index + component.rows_amount - 1;
+
                 std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
 
                 // selector goes onto last row and gate uses all rows
-                assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
+                assignment.enable_selector(selector_index, last_row);
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, last_row);
+#endif
 
                 generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/tanh.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/tanh.hpp
@@ -144,7 +144,7 @@ namespace nil {
                 class gate_manifest_type : public component_gate_manifest {
                 public:
                     std::uint32_t gates_amount() const override {
-                        return 4;
+                        return fix_tanh::gates_amount;
                     }
                 };
 
@@ -173,6 +173,8 @@ namespace nil {
                            div_component::get_rows_amount(witness_amount, lookup_column_amount, m1, m2) + 1;
                 }
 
+                constexpr static const std::size_t gates_amount =
+                    exp_component::gates_amount + div_component::gates_amount + range_component::gates_amount + 1;
                 const std::size_t rows_amount =
                     get_rows_amount(this->witness_amount(), 0, range.get_m1(), range.get_m2());
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/tanh.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/tanh.hpp
@@ -138,6 +138,8 @@ namespace nil {
 
                 using var = typename component_type::var;
                 using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
 
                 class gate_manifest_type : public component_gate_manifest {
                 public:
@@ -247,6 +249,19 @@ namespace nil {
                         return {output};
                     }
                 };
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    // includes all required ones
+                    return exp.component_custom_lookup_tables();
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    // includes all required ones
+                    return exp.component_lookup_tables();
+                }
+#endif
 
                 template<typename WitnessContainerType, typename ConstantContainerType,
                          typename PublicInputContainerType>

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/tanh.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/tanh.hpp
@@ -239,12 +239,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const fix_tanh &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     result_type(const fix_tanh &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -308,13 +308,13 @@ namespace nil {
                 // Exp input
                 typename plonk_fixedpoint_tanh<BlueprintFieldType, ArithmetizationParams>::exp_component::input_type
                     exp_input;
-                exp_input.x = var(magic(var_pos.exp_x), false);
+                exp_input.x = var(splat(var_pos.exp_x), false);
 
                 // Div input
                 typename plonk_fixedpoint_tanh<BlueprintFieldType, ArithmetizationParams>::div_component::input_type
                     div_input;
-                div_input.x = var(magic(var_pos.div_x), false);
-                div_input.y = var(magic(var_pos.div_y), false);
+                div_input.x = var(splat(var_pos.div_x), false);
+                div_input.y = var(splat(var_pos.div_y), false);
 
                 // Range input
                 typename plonk_fixedpoint_tanh<BlueprintFieldType, ArithmetizationParams>::range_component::input_type
@@ -327,7 +327,7 @@ namespace nil {
                 auto x_val = var_value(assignment, instance_input.x);
 
                 // Assign range gadget
-                assignment.witness(magic(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
 
                 auto range_out = generate_assignments(range_comp, assignment, range_input, var_pos.range_row);
 
@@ -337,28 +337,28 @@ namespace nil {
 
                 // Assign exp gadget
                 auto exp_x_val = x_val * 2 * in_val;
-                assignment.witness(magic(var_pos.exp_x)) = exp_x_val;
+                assignment.witness(splat(var_pos.exp_x)) = exp_x_val;
 
                 auto exp_out = generate_assignments(exp_comp, assignment, exp_input, var_pos.exp_row);
 
                 auto exp_y_val = var_value(assignment, exp_out.output);
-                assignment.witness(magic(var_pos.exp_y)) = exp_y_val;
+                assignment.witness(splat(var_pos.exp_y)) = exp_y_val;
 
                 // Assign div gadget
                 auto one = typename plonk_fixedpoint_tanh<BlueprintFieldType, ArithmetizationParams>::value_type(
                     div_comp.get_delta());
                 auto div_x_val = exp_y_val - one;
                 auto div_y_val = exp_y_val + one;
-                assignment.witness(magic(var_pos.div_x)) = div_x_val;
-                assignment.witness(magic(var_pos.div_y)) = div_y_val;
+                assignment.witness(splat(var_pos.div_x)) = div_x_val;
+                assignment.witness(splat(var_pos.div_y)) = div_y_val;
 
                 auto div_out = generate_assignments(div_comp, assignment, div_input, var_pos.div_row);
 
                 auto div_z_val = var_value(assignment, div_out.output);
-                assignment.witness(magic(var_pos.div_z)) = div_z_val;
+                assignment.witness(splat(var_pos.div_z)) = div_z_val;
 
                 auto y_val = div_z_val * in_val + component.get_tanh_min() * lt_val + component.get_tanh_max() * gt_val;
-                assignment.witness(magic(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
 
                 return typename plonk_fixedpoint_tanh<BlueprintFieldType, ArithmetizationParams>::result_type(
                     component, start_row_index);
@@ -384,16 +384,16 @@ namespace nil {
                                                                                              static_cast<std::size_t>(
                                                                                                  var_pos.range_row));
 
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
-                auto exp_x = var(magic(var_pos.exp_x));
-                auto exp_y = var(magic(var_pos.exp_y));
-                auto div_x = var(magic(var_pos.div_x));
-                auto div_y = var(magic(var_pos.div_y));
-                auto div_z = var(magic(var_pos.div_z));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto exp_x = var(splat(var_pos.exp_x));
+                auto exp_y = var(splat(var_pos.exp_y));
+                auto div_x = var(splat(var_pos.div_x));
+                auto div_y = var(splat(var_pos.div_y));
+                auto div_z = var(splat(var_pos.div_z));
 
-                auto const_min = var(magic(var_pos.const_min), true, var::column_type::constant);
-                auto const_max = var(magic(var_pos.const_max), true, var::column_type::constant);
+                auto const_min = var(splat(var_pos.const_min), true, var::column_type::constant);
+                auto const_max = var(splat(var_pos.const_max), true, var::column_type::constant);
 
                 auto in = range_res.in;
                 auto lt = range_res.lt;
@@ -441,9 +441,9 @@ namespace nil {
                                                    ArithmetizationParams>::div_component::result_type(div_comp,
                                                                                                       div_row);
 
-                auto x = var(magic(var_pos.x));
-                auto exp_y = var(magic(var_pos.exp_y));
-                auto div_z = var(magic(var_pos.div_z));
+                auto x = var(splat(var_pos.x));
+                auto exp_y = var(splat(var_pos.exp_y));
+                auto div_z = var(splat(var_pos.div_z));
 
                 bp.add_copy_constraint({instance_input.x, x});
                 bp.add_copy_constraint({exp_res.output, exp_y});
@@ -471,13 +471,13 @@ namespace nil {
                 // Exp input
                 typename plonk_fixedpoint_tanh<BlueprintFieldType, ArithmetizationParams>::exp_component::input_type
                     exp_input;
-                exp_input.x = var(magic(var_pos.exp_x), false);
+                exp_input.x = var(splat(var_pos.exp_x), false);
 
                 // Div input
                 typename plonk_fixedpoint_tanh<BlueprintFieldType, ArithmetizationParams>::div_component::input_type
                     div_input;
-                div_input.x = var(magic(var_pos.div_x), false);
-                div_input.y = var(magic(var_pos.div_y), false);
+                div_input.x = var(splat(var_pos.div_x), false);
+                div_input.y = var(splat(var_pos.div_y), false);
 
                 // Range input
                 typename plonk_fixedpoint_tanh<BlueprintFieldType, ArithmetizationParams>::range_component::input_type
@@ -514,8 +514,8 @@ namespace nil {
 
                 const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
 
-                assignment.constant(magic(var_pos.const_min)) = component.get_tanh_min();
-                assignment.constant(magic(var_pos.const_max)) = component.get_tanh_max();
+                assignment.constant(splat(var_pos.const_min)) = component.get_tanh_min();
+                assignment.constant(splat(var_pos.const_max)) = component.get_tanh_max();
             }
 
         }    // namespace components

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp
@@ -459,7 +459,7 @@ namespace nil {
                         }
 
                         // TRIGON 32
-                        if (requires_trig_table(test.component) && test.m2 == 1) {
+                        if (requires_trig_table(test.component) && test.m2 == 2) {
                             lookup_tables[fixedpoint_trigon_32_table<BlueprintFieldType>::FULL_SIN_A] =
                                 0;    // REQUIRED_TABLE
                             lookup_tables[fixedpoint_trigon_32_table<BlueprintFieldType>::FULL_SIN_B] =
@@ -760,11 +760,7 @@ namespace nil {
                         BLUEPRINT_RELEASE_ASSERT(var_value(assignment, vars[i]) == outputs[i]);
                     }
 
-                    // std::cout << "Component " << component_name << " (" << (int)m1 << ", " << (int)m2 << ")
-                    // at row "
-                    //           << current_row_index << " with " << component_rows + input_output_rows << "
-                    //           rows"
-                    //           << std::endl;
+                    // std::cout << "Component " << component_name << " (" << (int)m1 << ", " << (int)m2 << ") at row " << current_row_index << " with " << component_rows + input_output_rows << " rows"   << std::endl;
 
                     current_row_index += component_rows + input_output_rows;
                 }

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp
@@ -94,6 +94,13 @@ namespace nil {
                     return testcases;
                 }
 
+///////////////////////////////////////////////////////////////////////////////
+//  macro
+#define macro_rows_amount(name, ...)                                                     \
+    name<ArithmetizationType, BlueprintFieldType, NonNativePolicyType>::get_rows_amount( \
+        witness_amount, lookup_column_amount, ##__VA_ARGS__);
+                ///////////////////////////////////////////////////////////////////////////////
+
                 static std::size_t get_component_rows_amount(FixedPointComponents component, std::size_t witness_amount,
                                                              std::size_t lookup_column_amount, uint8_t m1, uint8_t m2) {
                     using ArithmetizationType =
@@ -101,110 +108,65 @@ namespace nil {
 
                     switch (component) {
                         case FixedPointComponents::ADD:
-                            return addition<ArithmetizationType, BlueprintFieldType,
-                                            NonNativePolicyType>::get_rows_amount(witness_amount, lookup_column_amount);
+                            return macro_rows_amount(addition);
                         case FixedPointComponents::ARGMAX:
-                            return fix_argmax<ArithmetizationType, BlueprintFieldType,
-                                              NonNativePolicyType>::get_rows_amount(witness_amount,
-                                                                                    lookup_column_amount, m1, m2);
+                            return macro_rows_amount(fix_argmax, m1, m2);
                         case FixedPointComponents::ARGMIN:
-                            return fix_argmin<ArithmetizationType, BlueprintFieldType,
-                                              NonNativePolicyType>::get_rows_amount(witness_amount,
-                                                                                    lookup_column_amount, m1, m2);
+                            return macro_rows_amount(fix_argmin, m1, m2);
                         case FixedPointComponents::CMP:
-                            return fix_cmp<ArithmetizationType, BlueprintFieldType,
-                                           NonNativePolicyType>::get_rows_amount(witness_amount, lookup_column_amount);
+                            return macro_rows_amount(fix_cmp);
                         case FixedPointComponents::CMP_EXTENDED:
-                            return fix_cmp_extended<ArithmetizationType, BlueprintFieldType,
-                                                    NonNativePolicyType>::get_rows_amount(witness_amount,
-                                                                                          lookup_column_amount);
+                            return macro_rows_amount(fix_cmp_extended);
                         case FixedPointComponents::CMP_MIN_MAX:
-                            return fix_cmp_min_max<ArithmetizationType, BlueprintFieldType,
-                                                   NonNativePolicyType>::get_rows_amount(witness_amount,
-                                                                                         lookup_column_amount);
+                            return macro_rows_amount(fix_cmp_min_max);
                         case FixedPointComponents::DIV_BY_POS:
-                            return fix_div_by_pos<ArithmetizationType, BlueprintFieldType,
-                                                  NonNativePolicyType>::get_rows_amount(witness_amount,
-                                                                                        lookup_column_amount, m1, m2);
+                            return macro_rows_amount(fix_div_by_pos, m1, m2);
                         case FixedPointComponents::DIV:
-                            return fix_div<ArithmetizationType, BlueprintFieldType,
-                                           NonNativePolicyType>::get_rows_amount(witness_amount, lookup_column_amount,
-                                                                                 m1, m2);
+                            return macro_rows_amount(fix_div, m1, m2);
                         // case FixedPointComponents::DOT_RESCALE1:
                         // case FixedPointComponents::DOT_RESCALE2:
                         case FixedPointComponents::EXP:
-                            return fix_exp<ArithmetizationType, BlueprintFieldType,
-                                           NonNativePolicyType>::get_rows_amount(witness_amount, lookup_column_amount);
+                            return macro_rows_amount(fix_exp);
                         case FixedPointComponents::EXP_RANGED:
-                            return fix_exp_ranged<ArithmetizationType, BlueprintFieldType,
-                                                  NonNativePolicyType>::get_rows_amount(witness_amount,
-                                                                                        lookup_column_amount, m1, m2);
+                            return macro_rows_amount(fix_exp_ranged, m1, m2);
                         case FixedPointComponents::GATHER_ACC:
-                            return fix_gather_acc<ArithmetizationType, BlueprintFieldType,
-                                                  NonNativePolicyType>::get_rows_amount(witness_amount,
-                                                                                        lookup_column_amount);
+                            return macro_rows_amount(fix_gather_acc);
                         case FixedPointComponents::LOG:
-                            return fix_log<ArithmetizationType, BlueprintFieldType,
-                                           NonNativePolicyType>::get_rows_amount(witness_amount, lookup_column_amount,
-                                                                                 m1, m2);
+                            return macro_rows_amount(fix_log, m1, m2);
                         case FixedPointComponents::MAX:
-                            return fix_max<ArithmetizationType, BlueprintFieldType,
-                                           NonNativePolicyType>::get_rows_amount(witness_amount, lookup_column_amount);
+                            return macro_rows_amount(fix_max);
                         case FixedPointComponents::MIN:
-                            return fix_min<ArithmetizationType, BlueprintFieldType,
-                                           NonNativePolicyType>::get_rows_amount(witness_amount, lookup_column_amount);
+                            return macro_rows_amount(fix_min);
                         case FixedPointComponents::MUL_RESCALE:
-                            return fix_mul_rescale<ArithmetizationType, BlueprintFieldType,
-                                                   NonNativePolicyType>::get_rows_amount(witness_amount,
-                                                                                         lookup_column_amount);
+                            return macro_rows_amount(fix_mul_rescale);
                         case FixedPointComponents::MUL_RESCALE_CONST:
-                            return fix_mul_rescale_const<ArithmetizationType, BlueprintFieldType,
-                                                         NonNativePolicyType>::get_rows_amount(witness_amount,
-                                                                                               lookup_column_amount);
+                            return macro_rows_amount(fix_mul_rescale_const);
                         case FixedPointComponents::NEG:
-                            return fix_neg<ArithmetizationType, BlueprintFieldType,
-                                           NonNativePolicyType>::get_rows_amount(witness_amount, lookup_column_amount);
+                            return macro_rows_amount(fix_neg);
                         case FixedPointComponents::RANGE:
-                            return fix_range<ArithmetizationType, BlueprintFieldType,
-                                             NonNativePolicyType>::get_rows_amount(witness_amount, lookup_column_amount,
-                                                                                   m1, m2);
+                            return macro_rows_amount(fix_range, m1, m2);
                         case FixedPointComponents::REM:
-                            return fix_rem<ArithmetizationType, BlueprintFieldType,
-                                           NonNativePolicyType>::get_rows_amount(witness_amount, lookup_column_amount,
-                                                                                 m1, m2);
+                            return macro_rows_amount(fix_rem, m1, m2);
                         case FixedPointComponents::RESCALE:
-                            return fix_rescale<ArithmetizationType, BlueprintFieldType,
-                                               NonNativePolicyType>::get_rows_amount(witness_amount,
-                                                                                     lookup_column_amount);
+                            return macro_rows_amount(fix_rescale);
                         case FixedPointComponents::SELECT:
-                            return fix_select<ArithmetizationType, BlueprintFieldType,
-                                              NonNativePolicyType>::get_rows_amount(witness_amount,
-                                                                                    lookup_column_amount);
+                            return macro_rows_amount(fix_select);
                         case FixedPointComponents::SQRT:
-                            return fix_sqrt<ArithmetizationType, BlueprintFieldType,
-                                            NonNativePolicyType>::get_rows_amount(witness_amount, lookup_column_amount,
-                                                                                  m1, m2);
+                            return macro_rows_amount(fix_sqrt, m1, m2);
                         case FixedPointComponents::SQRT_FLOOR:
-                            return fix_sqrt_floor<ArithmetizationType, BlueprintFieldType,
-                                                  NonNativePolicyType>::get_rows_amount(witness_amount,
-                                                                                        lookup_column_amount, m1, m2);
+                            return macro_rows_amount(fix_sqrt_floor, m1, m2);
                         case FixedPointComponents::SUB:
-                            return subtraction<ArithmetizationType, BlueprintFieldType,
-                                               NonNativePolicyType>::get_rows_amount(witness_amount,
-                                                                                     lookup_column_amount);
+                            return macro_rows_amount(subtraction);
                         case FixedPointComponents::TANH:
-                            return fix_tanh<ArithmetizationType, BlueprintFieldType,
-                                            NonNativePolicyType>::get_rows_amount(witness_amount, lookup_column_amount,
-                                                                                  m1, m2);
+                            return macro_rows_amount(fix_tanh, m1, m2);
                         case FixedPointComponents::TO_FIXEDPOINT:
-                            return int_to_fix<ArithmetizationType, BlueprintFieldType,
-                                              NonNativePolicyType>::get_rows_amount(witness_amount,
-                                                                                    lookup_column_amount);
+                            return macro_rows_amount(int_to_fix);
                         default:
                             BLUEPRINT_RELEASE_ASSERT(false);
                     }
                     return 0;
                 }
+#undef macro_rows_amount
 
                 void add_testcase(FixedPointComponents component, std::vector<value_type> &inputs,
                                   std::vector<value_type> &outputs, std::vector<value_type> &constants, uint8_t m1,
@@ -339,6 +301,34 @@ namespace nil {
                 fix_tester<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
                            BlueprintFieldType, basic_non_native_policy<BlueprintFieldType>>;
 
+///////////////////////////////////////////////////////////////////////////////
+//  macro
+#define macro_assigner(num_constant, ...)                                                                          \
+    BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());                                   \
+    BLUEPRINT_RELEASE_ASSERT(constants.size() == num_constant);                                                    \
+    new_component_type component_instance(witness_list, constant_list, public_input_list, ##__VA_ARGS__);          \
+    vars = generate_assignments(component_instance, assignment, instance_input, current_row_index + 1).all_vars(); \
+    component_rows = component_instance.rows_amount;
+///////////////////////////////////////////////////////////////////////////////
+#define macro_assigner_1_input(name, num_constant, ...)                                                     \
+    using new_component_type = name<ArithmetizationType, BlueprintFieldType, PolicyType>;                   \
+    typename new_component_type::input_type instance_input {var(component.W(0), current_row_index, false)}; \
+    macro_assigner(num_constant, ##__VA_ARGS__)
+///////////////////////////////////////////////////////////////////////////////
+#define macro_assigner_2_inputs(name, num_constant, ...)                                                    \
+    using new_component_type = name<ArithmetizationType, BlueprintFieldType, PolicyType>;                   \
+    typename new_component_type::input_type instance_input {var(component.W(0), current_row_index, false),  \
+                                                            var(component.W(1), current_row_index, false)}; \
+    macro_assigner(num_constant, ##__VA_ARGS__)
+///////////////////////////////////////////////////////////////////////////////
+#define macro_assigner_3_inputs(name, num_constant, ...)                                                    \
+    using new_component_type = name<ArithmetizationType, BlueprintFieldType, PolicyType>;                   \
+    typename new_component_type::input_type instance_input {var(component.W(0), current_row_index, false),  \
+                                                            var(component.W(1), current_row_index, false),  \
+                                                            var(component.W(2), current_row_index, false)}; \
+    macro_assigner(num_constant, ##__VA_ARGS__)
+            ///////////////////////////////////////////////////////////////////////////////
+
             template<typename BlueprintFieldType, typename ArithmetizationParams>
             typename plonk_fixedpoint_tester<BlueprintFieldType, ArithmetizationParams>::result_type
                 generate_assignments(
@@ -383,161 +373,37 @@ namespace nil {
 
                     switch (test.component) {
                         case FixedPointComponents::ADD: {
-                            using new_component_type = addition<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_2_inputs(addition, 0);
                             break;
                         }
                         case FixedPointComponents::ARGMAX: {
-                            using new_component_type = fix_argmax<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false),
-                                var(component.W(2), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 2);
-
-                            // Assign component
                             bool select_last_index = constants[1] == 0 ? false : true;
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2, constants[0], select_last_index);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_3_inputs(fix_argmax, 2, m1, m2, constants[0], select_last_index);
                             break;
                         }
                         case FixedPointComponents::ARGMIN: {
-                            using new_component_type = fix_argmin<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false),
-                                var(component.W(2), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 2);
-
-                            // Assign component
                             bool select_last_index = constants[1] == 0 ? false : true;
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2, constants[0], select_last_index);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_3_inputs(fix_argmin, 2, m1, m2, constants[0], select_last_index);
                             break;
                         }
                         case FixedPointComponents::CMP: {
-                            using new_component_type = fix_cmp<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_2_inputs(fix_cmp, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::CMP_EXTENDED: {
-                            using new_component_type =
-                                fix_cmp_extended<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_2_inputs(fix_cmp_extended, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::CMP_MIN_MAX: {
-                            using new_component_type =
-                                fix_cmp_min_max<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_2_inputs(fix_cmp_min_max, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::DIV_BY_POS: {
-                            using new_component_type =
-                                fix_div_by_pos<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_2_inputs(fix_div_by_pos, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::DIV: {
-                            using new_component_type = fix_div<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_2_inputs(fix_div, 0, m1, m2);
                             break;
                         }
                         // case FixedPointComponents::DOT_RESCALE1: {
@@ -547,334 +413,75 @@ namespace nil {
                         //     break;
                         // }
                         case FixedPointComponents::EXP: {
-                            using new_component_type = fix_exp<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_1_input(fix_exp, 0, m2);
                             break;
                         }
                         case FixedPointComponents::EXP_RANGED: {
-                            using new_component_type =
-                                fix_exp_ranged<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_1_input(fix_exp_ranged, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::GATHER_ACC: {
-                            using new_component_type =
-                                fix_gather_acc<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false),
-                                var(component.W(2), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 1);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list,
-                                                                  constants[0]);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_3_inputs(fix_gather_acc, 1, constants[0]);
                             break;
                         }
                         case FixedPointComponents::LOG: {
-                            using new_component_type = fix_log<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_1_input(fix_log, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::MAX: {
-                            using new_component_type = fix_max<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_2_inputs(fix_max, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::MIN: {
-                            using new_component_type = fix_min<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_2_inputs(fix_min, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::MUL_RESCALE: {
-                            using new_component_type =
-                                fix_mul_rescale<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_2_inputs(fix_mul_rescale, 0, m2);
                             break;
                         }
                         case FixedPointComponents::MUL_RESCALE_CONST: {
-                            using new_component_type =
-                                fix_mul_rescale_const<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 1);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list,
-                                                                  constants[0], m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_1_input(fix_mul_rescale_const, 1, constants[0], m2);
                             break;
                         }
                         case FixedPointComponents::NEG: {
-                            using new_component_type = fix_neg<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_1_input(fix_neg, 0);
                             break;
                         }
                         case FixedPointComponents::RANGE: {
-                            using new_component_type = fix_range<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 2);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2, constants[0], constants[1]);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_1_input(fix_range, 2, m1, m2, constants[0], constants[1]);
                             break;
                         }
                         case FixedPointComponents::REM: {
-                            using new_component_type = fix_rem<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_2_inputs(fix_rem, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::RESCALE: {
-                            using new_component_type = fix_rescale<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_1_input(fix_rescale, 0, m2);
                             break;
                         }
                         case FixedPointComponents::SELECT: {
-                            using new_component_type = fix_select<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false),
-                                var(component.W(2), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_3_inputs(fix_select, 0);
                             break;
                         }
                         case FixedPointComponents::SQRT: {
-                            using new_component_type = fix_sqrt<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_1_input(fix_sqrt, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::SQRT_FLOOR: {
-                            using new_component_type =
-                                fix_sqrt_floor<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_1_input(fix_sqrt_floor, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::SUB: {
-                            using new_component_type = subtraction<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_2_inputs(subtraction, 0);
                             break;
                         }
                         case FixedPointComponents::TANH: {
-                            using new_component_type = fix_tanh<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_1_input(fix_tanh, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::TO_FIXEDPOINT: {
-                            using new_component_type = int_to_fix<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // Assign component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m2);
-                            vars = generate_assignments(component_instance, assignment, instance_input,
-                                                        current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_assigner_1_input(int_to_fix, 0, m2);
                             break;
                         }
                         default:
@@ -893,6 +500,38 @@ namespace nil {
                 return typename plonk_fixedpoint_tester<BlueprintFieldType, ArithmetizationParams>::result_type(
                     component, start_row_index);
             }
+#undef macro_assigner
+#undef macro_assigner_1_input
+#undef macro_assigner_2_inputs
+#undef macro_assigner_3_inputs
+
+///////////////////////////////////////////////////////////////////////////////
+//  macro
+#define macro_circuit(num_constant, ...)                                                                           \
+    BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());                                   \
+    BLUEPRINT_RELEASE_ASSERT(constants.size() == num_constant);                                                    \
+    new_component_type component_instance(witness_list, constant_list, public_input_list, ##__VA_ARGS__);          \
+    vars = generate_circuit(component_instance, bp, assignment, instance_input, current_row_index + 1).all_vars(); \
+    component_rows = component_instance.rows_amount;
+///////////////////////////////////////////////////////////////////////////////
+#define macro_circuit_1_input(name, num_constant, ...)                                                      \
+    using new_component_type = name<ArithmetizationType, BlueprintFieldType, PolicyType>;                   \
+    typename new_component_type::input_type instance_input {var(component.W(0), current_row_index, false)}; \
+    macro_circuit(num_constant, ##__VA_ARGS__)
+///////////////////////////////////////////////////////////////////////////////
+#define macro_circuit_2_inputs(name, num_constant, ...)                                                     \
+    using new_component_type = name<ArithmetizationType, BlueprintFieldType, PolicyType>;                   \
+    typename new_component_type::input_type instance_input {var(component.W(0), current_row_index, false),  \
+                                                            var(component.W(1), current_row_index, false)}; \
+    macro_circuit(num_constant, ##__VA_ARGS__)
+///////////////////////////////////////////////////////////////////////////////
+#define macro_circuit_3_inputs(name, num_constant, ...)                                                     \
+    using new_component_type = name<ArithmetizationType, BlueprintFieldType, PolicyType>;                   \
+    typename new_component_type::input_type instance_input {var(component.W(0), current_row_index, false),  \
+                                                            var(component.W(1), current_row_index, false),  \
+                                                            var(component.W(2), current_row_index, false)}; \
+    macro_circuit(num_constant, ##__VA_ARGS__)
+            ///////////////////////////////////////////////////////////////////////////////
 
             template<typename BlueprintFieldType, typename ArithmetizationParams>
             typename plonk_fixedpoint_tester<BlueprintFieldType, ArithmetizationParams>::result_type generate_circuit(
@@ -929,161 +568,37 @@ namespace nil {
 
                     switch (test.component) {
                         case FixedPointComponents::ADD: {
-                            using new_component_type = addition<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_2_inputs(addition, 0);
                             break;
                         }
                         case FixedPointComponents::ARGMAX: {
-                            using new_component_type = fix_argmax<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false),
-                                var(component.W(2), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 2);
-
-                            // layout component
                             bool select_last_index = constants[1] == 0 ? false : true;
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2, constants[0], select_last_index);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_3_inputs(fix_argmax, 2, m1, m2, constants[0], select_last_index);
                             break;
                         }
                         case FixedPointComponents::ARGMIN: {
-                            using new_component_type = fix_argmin<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false),
-                                var(component.W(2), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 2);
-
-                            // layout component
                             bool select_last_index = constants[1] == 0 ? false : true;
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2, constants[0], select_last_index);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_3_inputs(fix_argmin, 2, m1, m2, constants[0], select_last_index);
                             break;
                         }
                         case FixedPointComponents::CMP: {
-                            using new_component_type = fix_cmp<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_2_inputs(fix_cmp, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::CMP_EXTENDED: {
-                            using new_component_type =
-                                fix_cmp_extended<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_2_inputs(fix_cmp_extended, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::CMP_MIN_MAX: {
-                            using new_component_type =
-                                fix_cmp_min_max<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_2_inputs(fix_cmp_min_max, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::DIV_BY_POS: {
-                            using new_component_type =
-                                fix_div_by_pos<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_2_inputs(fix_div_by_pos, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::DIV: {
-                            using new_component_type = fix_div<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_2_inputs(fix_div, 0, m1, m2);
                             break;
                         }
                         // case FixedPointComponents::DOT_RESCALE1: {
@@ -1093,334 +608,75 @@ namespace nil {
                         //     break;
                         // }
                         case FixedPointComponents::EXP: {
-                            using new_component_type = fix_exp<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_1_input(fix_exp, 0, m2);
                             break;
                         }
                         case FixedPointComponents::EXP_RANGED: {
-                            using new_component_type =
-                                fix_exp_ranged<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_1_input(fix_exp_ranged, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::GATHER_ACC: {
-                            using new_component_type =
-                                fix_gather_acc<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false),
-                                var(component.W(2), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 1);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list,
-                                                                  constants[0]);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_3_inputs(fix_gather_acc, 1, constants[0]);
                             break;
                         }
                         case FixedPointComponents::LOG: {
-                            using new_component_type = fix_log<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_1_input(fix_log, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::MAX: {
-                            using new_component_type = fix_max<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_2_inputs(fix_max, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::MIN: {
-                            using new_component_type = fix_min<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_2_inputs(fix_min, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::MUL_RESCALE: {
-                            using new_component_type =
-                                fix_mul_rescale<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_2_inputs(fix_mul_rescale, 0, m2);
                             break;
                         }
                         case FixedPointComponents::MUL_RESCALE_CONST: {
-                            using new_component_type =
-                                fix_mul_rescale_const<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 1);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list,
-                                                                  constants[0], m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_1_input(fix_mul_rescale_const, 1, constants[0], m2);
                             break;
                         }
                         case FixedPointComponents::NEG: {
-                            using new_component_type = fix_neg<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_1_input(fix_neg, 0);
                             break;
                         }
                         case FixedPointComponents::RANGE: {
-                            using new_component_type = fix_range<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 2);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2, constants[0], constants[1]);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_1_input(fix_range, 2, m1, m2, constants[0], constants[1]);
                             break;
                         }
                         case FixedPointComponents::REM: {
-                            using new_component_type = fix_rem<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_2_inputs(fix_rem, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::RESCALE: {
-                            using new_component_type = fix_rescale<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_1_input(fix_rescale, 0, m2);
                             break;
                         }
                         case FixedPointComponents::SELECT: {
-                            using new_component_type = fix_select<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false),
-                                var(component.W(2), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_3_inputs(fix_select, 0);
                             break;
                         }
                         case FixedPointComponents::SQRT: {
-                            using new_component_type = fix_sqrt<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_1_input(fix_sqrt, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::SQRT_FLOOR: {
-                            using new_component_type =
-                                fix_sqrt_floor<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_1_input(fix_sqrt_floor, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::SUB: {
-                            using new_component_type = subtraction<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false),
-                                var(component.W(1), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_2_inputs(subtraction, 0);
                             break;
                         }
                         case FixedPointComponents::TANH: {
-                            using new_component_type = fix_tanh<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m1,
-                                                                  m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_1_input(fix_tanh, 0, m1, m2);
                             break;
                         }
                         case FixedPointComponents::TO_FIXEDPOINT: {
-                            using new_component_type = int_to_fix<ArithmetizationType, BlueprintFieldType, PolicyType>;
-
-                            // Inputs
-                            typename new_component_type::input_type instance_input {
-                                var(component.W(0), current_row_index, false)};
-                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
-                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
-
-                            // layout component
-                            new_component_type component_instance(witness_list, constant_list, public_input_list, m2);
-                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
-                                                    current_row_index + 1)
-                                       .all_vars();
-                            component_rows = component_instance.rows_amount;
+                            macro_circuit_1_input(int_to_fix, 0, m2);
                             break;
                         }
                         default:
@@ -1440,6 +696,10 @@ namespace nil {
                 return typename plonk_fixedpoint_tester<BlueprintFieldType, ArithmetizationParams>::result_type(
                     component, start_row_index);
             }
+#undef macro_circuit
+#undef macro_circuit_1_input
+#undef macro_circuit_2_inputs
+#undef macro_circuit_3_inputs
 
             template<typename BlueprintFieldType, typename ArithmetizationParams, typename ComponentType>
             struct is_component_tester : std::false_type { };

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp
@@ -306,19 +306,13 @@ namespace nil {
                     auto table = std::shared_ptr<lookup_table_definition>(new range_table());
                     result.push_back(table);
 
-                    auto table_a_16 =
-                        std::shared_ptr<lookup_table_definition>(new fixedpoint_exp_a16_table<BlueprintFieldType>());
-                    auto table_b_16 =
-                        std::shared_ptr<lookup_table_definition>(new fixedpoint_exp_b16_table<BlueprintFieldType>());
-                    result.push_back(table_a_16);
-                    result.push_back(table_b_16);
+                    auto table_16 =
+                        std::shared_ptr<lookup_table_definition>(new fixedpoint_exp_16_table<BlueprintFieldType>());
+                    result.push_back(table_16);
 
-                    auto table_a_32 =
-                        std::shared_ptr<lookup_table_definition>(new fixedpoint_exp_a32_table<BlueprintFieldType>());
-                    auto table_b_32 =
-                        std::shared_ptr<lookup_table_definition>(new fixedpoint_exp_b32_table<BlueprintFieldType>());
-                    result.push_back(table_a_32);
-                    result.push_back(table_b_32);
+                    auto table_32 =
+                        std::shared_ptr<lookup_table_definition>(new fixedpoint_exp_32_table<BlueprintFieldType>());
+                    result.push_back(table_32);
 
                     return result;
                 }
@@ -327,14 +321,10 @@ namespace nil {
                     std::map<std::string, std::size_t> lookup_tables;
                     lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
 
-                    lookup_tables[fixedpoint_exp_a16_table<BlueprintFieldType>::FULL_TABLE_NAME] =
-                        0;    // REQUIRED_TABLE
-                    lookup_tables[fixedpoint_exp_b16_table<BlueprintFieldType>::FULL_TABLE_NAME] =
-                        0;    // REQUIRED_TABLE
-                    lookup_tables[fixedpoint_exp_a32_table<BlueprintFieldType>::FULL_TABLE_NAME] =
-                        0;    // REQUIRED_TABLE
-                    lookup_tables[fixedpoint_exp_b32_table<BlueprintFieldType>::FULL_TABLE_NAME] =
-                        0;    // REQUIRED_TABLE
+                    lookup_tables[fixedpoint_exp_16_table<BlueprintFieldType>::A_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    lookup_tables[fixedpoint_exp_16_table<BlueprintFieldType>::B_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    lookup_tables[fixedpoint_exp_32_table<BlueprintFieldType>::A_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    lookup_tables[fixedpoint_exp_32_table<BlueprintFieldType>::B_TABLE_NAME] = 0;    // REQUIRED_TABLE
 
                     return lookup_tables;
                 }

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp
@@ -286,19 +286,19 @@ namespace nil {
                     auto table = std::shared_ptr<lookup_table_definition>(new range_table());
                     result.push_back(table);
 
-                    //     auto table_a_16 = std::shared_ptr<lookup_table_definition>(
-                    //         new fixedpoint_exp_a16_table<BlueprintFieldType>());
-                    //     auto table_b_16 = std::shared_ptr<lookup_table_definition>(
-                    //         new fixedpoint_exp_b16_table<BlueprintFieldType>());
-                    //     result.push_back(table_a_16);
-                    //     result.push_back(table_b_16);
+                    auto table_a_16 =
+                        std::shared_ptr<lookup_table_definition>(new fixedpoint_exp_a16_table<BlueprintFieldType>());
+                    auto table_b_16 =
+                        std::shared_ptr<lookup_table_definition>(new fixedpoint_exp_b16_table<BlueprintFieldType>());
+                    result.push_back(table_a_16);
+                    result.push_back(table_b_16);
 
-                    //     auto table_a_32 = std::shared_ptr<lookup_table_definition>(
-                    //         new fixedpoint_exp_a32_table<BlueprintFieldType>());
-                    //     auto table_b_32 = std::shared_ptr<lookup_table_definition>(
-                    //         new fixedpoint_exp_b32_table<BlueprintFieldType>());
-                    //     result.push_back(table_a_32);
-                    //     result.push_back(table_b_32);
+                    auto table_a_32 =
+                        std::shared_ptr<lookup_table_definition>(new fixedpoint_exp_a32_table<BlueprintFieldType>());
+                    auto table_b_32 =
+                        std::shared_ptr<lookup_table_definition>(new fixedpoint_exp_b32_table<BlueprintFieldType>());
+                    result.push_back(table_a_32);
+                    result.push_back(table_b_32);
 
                     return result;
                 }
@@ -307,14 +307,14 @@ namespace nil {
                     std::map<std::string, std::size_t> lookup_tables;
                     lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
 
-                    //     lookup_tables[fixedpoint_exp_a16_table<BlueprintFieldType>::FULL_TABLE_NAME] =
-                    //         0;    // REQUIRED_TABLE
-                    //     lookup_tables[fixedpoint_exp_b16_table<BlueprintFieldType>::FULL_TABLE_NAME] =
-                    //         0;    // REQUIRED_TABLE
-                    //     lookup_tables[fixedpoint_exp_a32_table<BlueprintFieldType>::FULL_TABLE_NAME] =
-                    //         0;    // REQUIRED_TABLE
-                    //     lookup_tables[fixedpoint_exp_b32_table<BlueprintFieldType>::FULL_TABLE_NAME] =
-                    //         0;    // REQUIRED_TABLE
+                    lookup_tables[fixedpoint_exp_a16_table<BlueprintFieldType>::FULL_TABLE_NAME] =
+                        0;    // REQUIRED_TABLE
+                    lookup_tables[fixedpoint_exp_b16_table<BlueprintFieldType>::FULL_TABLE_NAME] =
+                        0;    // REQUIRED_TABLE
+                    lookup_tables[fixedpoint_exp_a32_table<BlueprintFieldType>::FULL_TABLE_NAME] =
+                        0;    // REQUIRED_TABLE
+                    lookup_tables[fixedpoint_exp_b32_table<BlueprintFieldType>::FULL_TABLE_NAME] =
+                        0;    // REQUIRED_TABLE
 
                     return lookup_tables;
                 }

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp
@@ -1,0 +1,395 @@
+#ifndef CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_TESTER_HPP
+#define CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_TESTER_HPP
+
+#include "nil/blueprint/components/algebra/fixedpoint/plonk/argmax.hpp"
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp"
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/exp.hpp"
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+
+            enum FixedPointComponents {
+                ARGMAX,
+                ARGMIN,
+                CMP,
+                CMP_EXTENDED,
+                CMP_MIN_MAX,
+                DIV_BY_POS,
+                DIV,
+                DOT_RESCALE1,
+                DOT_RESCALE2,
+                EXP,
+                EXP_RANGED,
+                GATHER_ACC,
+                LOG,
+                MAX,
+                MIN,
+                MUL_RESCALE,
+                MUL_RESCALE_CONST,
+                NEG,
+                RANGE,
+                REM,
+                RESCALE,
+                SELECT,
+                SQRT,
+                SQRT_FLOOR,
+                TANH,
+                TO_FIXEDPOINT
+            };
+
+            static constexpr uint8_t TESTER_MAX_CONSTANT_COLS = 2;
+            static constexpr uint8_t TESTER_MAX_PUBLIC_COLS = 10;
+
+            template<typename ArithmetizationType, typename FieldType, typename NonNativePolicyType>
+            class fix_tester;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams, typename NonNativePolicyType>
+            class fix_tester<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                             BlueprintFieldType, NonNativePolicyType>
+                : public plonk_component<BlueprintFieldType, ArithmetizationParams, TESTER_MAX_CONSTANT_COLS,
+                                         TESTER_MAX_PUBLIC_COLS> {
+            public:
+                using value_type = typename BlueprintFieldType::value_type;
+
+                struct testcase {
+                    FixedPointComponents component;
+                    std::vector<value_type> inputs;
+                    std::vector<value_type> outputs;
+                    std::vector<value_type> constants;
+                };
+
+            private:
+                std::vector<testcase> testcases;
+
+                uint8_t m1;    // Pre-comma 16-bit limbs
+                uint8_t m2;    // Post-comma 16-bit limbs
+
+                static uint8_t M(uint8_t m) {
+                    if (m == 0 || m > 2) {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+                    return m;
+                }
+
+            public:
+                uint8_t get_m() const {
+                    return m1 + m2;
+                }
+
+                uint8_t get_m1() const {
+                    return m1;
+                }
+
+                uint8_t get_m2() const {
+                    return m2;
+                }
+
+                const std::vector<testcase> &get_testcases() const {
+                    return testcases;
+                }
+
+                static std::size_t get_component_rows_amount(FixedPointComponents component, std::size_t witness_amount,
+                                                             std::size_t lookup_column_amount, uint8_t m1, uint8_t m2) {
+                    switch (component) {
+                        case FixedPointComponents::ARGMAX:
+                            return fix_argmax<
+                                crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                                BlueprintFieldType, NonNativePolicyType>::get_rows_amount(witness_amount,
+                                                                                          lookup_column_amount, m1, m2);
+                        default:
+                            BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+                    return 0;
+                }
+
+                void add_testcase(FixedPointComponents component, std::vector<value_type> &inputs,
+                                  std::vector<value_type> &outputs, std::vector<value_type> &constants) {
+                    testcase test;
+                    test.component = component;
+                    test.inputs = inputs;
+                    test.outputs = outputs;
+                    test.constants = constants;
+                    testcases.push_back(test);
+                    rows_amount += get_component_rows_amount(component, this->witness_amount(), 0, m1, m2);
+                }
+
+                std::vector<std::uint32_t> get_witness_list() const {
+                    std::vector<std::uint32_t> result;
+                    result.reserve(this->witness_amount());
+                    for (std::size_t i = 0; i < this->witness_amount(); ++i) {
+                        result.push_back(this->W(i));
+                    }
+                    return result;
+                }
+
+                std::array<std::uint32_t, TESTER_MAX_CONSTANT_COLS> get_constant_list() const {
+                    std::array<std::uint32_t, TESTER_MAX_CONSTANT_COLS> result;
+                    for (std::size_t i = 0; i < this->constant_amount(); ++i) {
+                        result[i] = this->C(i);
+                    }
+                    return result;
+                }
+
+                std::array<std::uint32_t, TESTER_MAX_PUBLIC_COLS> get_public_input_list() const {
+                    std::array<std::uint32_t, TESTER_MAX_PUBLIC_COLS> result;
+                    for (std::size_t i = 0; i < this->public_input_amount(); ++i) {
+                        result[i] = this->PI(i);
+                    }
+                    return result;
+                }
+
+                using component_type = plonk_component<BlueprintFieldType, ArithmetizationParams,
+                                                       TESTER_MAX_CONSTANT_COLS, TESTER_MAX_PUBLIC_COLS>;
+
+                using var = typename component_type::var;
+                using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::detail::lookup_table_definition<BlueprintFieldType>;
+                using range_table = fixedpoint_range_table<BlueprintFieldType>;
+
+                static manifest_type get_manifest() {
+                    static manifest_type manifest =
+                        manifest_type(std::shared_ptr<manifest_param>(new manifest_single_value_param(1)), false);
+                    return manifest;
+                }
+
+                std::size_t rows_amount = 0;
+
+                struct input_type {
+
+                    std::vector<var> all_vars() const {
+                        return {};
+                    }
+                };
+
+                struct result_type {
+
+                    result_type(const fix_tester &component, std::uint32_t start_row_index) {
+                    }
+
+                    result_type(const fix_tester &component, std::size_t start_row_index) {
+                    }
+
+                    std::vector<var> all_vars() const {
+                        return {};
+                    }
+                };
+
+// Allows disabling the lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result = {};
+                    auto table = std::shared_ptr<lookup_table_definition>(new range_table());
+
+                    if (m2 == 1) {
+                        auto table_a = std::shared_ptr<lookup_table_definition>(
+                            new fixedpoint_exp_a16_table<BlueprintFieldType>());
+                        auto table_b = std::shared_ptr<lookup_table_definition>(
+                            new fixedpoint_exp_b16_table<BlueprintFieldType>());
+                        result.push_back(table_a);
+                        result.push_back(table_b);
+                    } else if (m2 == 2) {
+                        auto table_a = std::shared_ptr<lookup_table_definition>(
+                            new fixedpoint_exp_a32_table<BlueprintFieldType>());
+                        auto table_b = std::shared_ptr<lookup_table_definition>(
+                            new fixedpoint_exp_b32_table<BlueprintFieldType>());
+                        result.push_back(table_a);
+                        result.push_back(table_b);
+                    } else {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+
+                    result.push_back(table);
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
+
+                    if (m2 == 1) {
+                        lookup_tables[fixedpoint_exp_a16_table<BlueprintFieldType>::FULL_TABLE_NAME] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_exp_b16_table<BlueprintFieldType>::FULL_TABLE_NAME] =
+                            0;    // REQUIRED_TABLE
+                    } else if (m2 == 2) {
+                        lookup_tables[fixedpoint_exp_a32_table<BlueprintFieldType>::FULL_TABLE_NAME] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_exp_b32_table<BlueprintFieldType>::FULL_TABLE_NAME] =
+                            0;    // REQUIRED_TABLE
+                    } else {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+
+                    return lookup_tables;
+                }
+#endif
+
+                template<typename WitnessContainerType, typename ConstantContainerType,
+                         typename PublicInputContainerType>
+                fix_tester(WitnessContainerType witness, ConstantContainerType constant,
+                           PublicInputContainerType public_input, uint8_t m1, uint8_t m2) :
+                    component_type(witness, constant, public_input, get_manifest()),
+                    m1(M(m1)), m2(M(m2)) {};
+
+                fix_tester(
+                    std::initializer_list<typename component_type::witness_container_type::value_type> witnesses,
+                    std::initializer_list<typename component_type::constant_container_type::value_type> constants,
+                    std::initializer_list<typename component_type::public_input_container_type::value_type>
+                        public_inputs,
+                    uint8_t m1, uint8_t m2, value_type index_y_, bool select_last_index) :
+                    component_type(witnesses, constants, public_inputs, get_manifest()),
+                    m1(M(m1)), m2(M(m2)) {};
+            };
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            using plonk_fixedpoint_tester =
+                fix_tester<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                           BlueprintFieldType, basic_non_native_policy<BlueprintFieldType>>;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_fixedpoint_tester<BlueprintFieldType, ArithmetizationParams>::result_type
+                generate_assignments(
+                    const plonk_fixedpoint_tester<BlueprintFieldType, ArithmetizationParams> &component,
+                    assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                        &assignment,
+                    const typename plonk_fixedpoint_tester<BlueprintFieldType, ArithmetizationParams>::input_type
+                        instance_input,
+                    const std::uint32_t start_row_index) {
+
+                using var = typename plonk_fixedpoint_argmax<BlueprintFieldType, ArithmetizationParams>::var;
+
+                auto witness_list = component.get_witness_list();
+                auto constant_list = component.get_constant_list();
+                auto public_input_list = component.get_public_input_list();
+
+                auto current_row_index = start_row_index;
+
+                for (auto &test : component.get_testcases()) {
+                    auto &inputs = test.inputs;
+                    auto &outputs = test.outputs;
+                    auto &constants = test.constants;
+
+                    BLUEPRINT_RELEASE_ASSERT(inputs.size() + outputs.size() <= public_input_list.size());
+
+                    // Put inputs and outputs in the public columns, we will have coppy constraints to them later
+                    for (std::size_t i = 0; i < inputs.size(); ++i) {
+                        assignment.public_input(component.PI(i), current_row_index) = inputs[i];
+                    }
+                    for (std::size_t i = 0; i < outputs.size(); ++i) {
+                        assignment.public_input(component.PI(i + inputs.size()), current_row_index) = outputs[i];
+                    }
+
+                    switch (test.component) {
+                        case FixedPointComponents::ARGMAX: {
+                            using new_component_type = fix_argmax<
+                                crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                                BlueprintFieldType, nil::blueprint::basic_non_native_policy<BlueprintFieldType>>;
+
+                            // Inputs
+                            typename new_component_type::input_type instance_input {
+                                var(component.PI(0), current_row_index, false, var::column_type::public_input),
+                                var(component.PI(1), current_row_index, false, var::column_type::public_input),
+                                var(component.PI(2), current_row_index, false, var::column_type::public_input)};
+                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
+
+                            // Assign component
+                            bool select_last_index = constants[1] == 0 ? false : true;
+                            new_component_type component_instance(witness_list, constant_list, public_input_list,
+                                                                  component.get_m1(), component.get_m2(), constants[0],
+                                                                  select_last_index);
+                            auto instance_result =
+                                generate_assignments(component_instance, assignment, instance_input, current_row_index);
+
+                            // Outputs
+                            auto vars = instance_result.all_vars();
+                            BLUEPRINT_RELEASE_ASSERT(vars.size() == outputs.size());
+                            for (auto i = 0; i < vars.size(); i++) {
+                                BLUEPRINT_RELEASE_ASSERT(var_value(assignment, vars[i]) == outputs[i]);
+                            }
+
+                            current_row_index += component_instance.rows_amount;
+                            break;
+                        }
+                        default:
+                            BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+                }
+
+                return typename plonk_fixedpoint_tester<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_fixedpoint_tester<BlueprintFieldType, ArithmetizationParams>::result_type generate_circuit(
+                const plonk_fixedpoint_tester<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_tester<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input,
+                const std::size_t start_row_index) {
+
+                using var = typename plonk_fixedpoint_argmax<BlueprintFieldType, ArithmetizationParams>::var;
+
+                auto witness_list = component.get_witness_list();
+                auto constant_list = component.get_constant_list();
+                auto public_input_list = component.get_public_input_list();
+
+                auto current_row_index = start_row_index;
+
+                for (auto &test : component.get_testcases()) {
+                    auto &inputs = test.inputs;
+                    auto &outputs = test.outputs;
+                    auto &constants = test.constants;
+
+                    BLUEPRINT_RELEASE_ASSERT(inputs.size() + outputs.size() <= public_input_list.size());
+
+                    switch (test.component) {
+                        case FixedPointComponents::ARGMAX: {
+                            using new_component_type = fix_argmax<
+                                crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                                BlueprintFieldType, nil::blueprint::basic_non_native_policy<BlueprintFieldType>>;
+
+                            // Inputs
+                            typename new_component_type::input_type instance_input {
+                                var(component.PI(0), current_row_index, false, var::column_type::public_input),
+                                var(component.PI(1), current_row_index, false, var::column_type::public_input),
+                                var(component.PI(2), current_row_index, false, var::column_type::public_input)};
+                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
+
+                            // layout component
+                            bool select_last_index = constants[1] == 0 ? false : true;
+                            new_component_type component_instance(witness_list, constant_list, public_input_list,
+                                                                  component.get_m1(), component.get_m2(), constants[0],
+                                                                  select_last_index);
+                            auto instance_result =
+                                generate_circuit(component_instance, bp, assignment, instance_input, current_row_index);
+
+                            // Copy constraints for outputs
+                            auto vars = instance_result.all_vars();
+                            BLUEPRINT_RELEASE_ASSERT(vars.size() == outputs.size());
+                            for (auto i = 0; i < vars.size(); i++) {
+                                bp.add_copy_constraint({var(component.PI(i + inputs.size()), current_row_index, false,
+                                                            var::column_type::public_input),
+                                                        vars[i]});
+                            }
+
+                            current_row_index += component_instance.rows_amount;
+                            break;
+                        }
+                        default:
+                            BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+                }
+
+                return typename plonk_fixedpoint_tester<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_TESTER_HPP

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp
@@ -11,12 +11,15 @@
 #include "nil/blueprint/components/algebra/fixedpoint/plonk/range.hpp"
 #include "nil/blueprint/components/algebra/fixedpoint/plonk/min.hpp"
 #include "nil/blueprint/components/algebra/fixedpoint/plonk/max.hpp"
+#include <nil/blueprint/components/algebra/fields/plonk/addition.hpp>
+#include <nil/blueprint/components/algebra/fields/plonk/subtraction.hpp>
 
 namespace nil {
     namespace blueprint {
         namespace components {
 
             enum FixedPointComponents {
+                ADD,
                 ARGMAX,
                 ARGMIN,
                 CMP,
@@ -41,6 +44,7 @@ namespace nil {
                 SELECT,
                 SQRT,
                 SQRT_FLOOR,
+                SUB,
                 TANH,
                 TO_FIXEDPOINT
             };
@@ -100,6 +104,9 @@ namespace nil {
                         crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
 
                     switch (component) {
+                        case FixedPointComponents::ADD:
+                            return addition<ArithmetizationType, BlueprintFieldType,
+                                            NonNativePolicyType>::get_rows_amount(witness_amount, lookup_column_amount);
                         case FixedPointComponents::ARGMAX:
                             return fix_argmax<ArithmetizationType, BlueprintFieldType,
                                               NonNativePolicyType>::get_rows_amount(witness_amount,
@@ -151,6 +158,10 @@ namespace nil {
                                                                                     lookup_column_amount);
                         // case FixedPointComponents::SQRT:
                         // case FixedPointComponents::SQRT_FLOOR:
+                        case FixedPointComponents::SUB:
+                            return subtraction<ArithmetizationType, BlueprintFieldType,
+                                               NonNativePolicyType>::get_rows_amount(witness_amount,
+                                                                                     lookup_column_amount);
                         // case FixedPointComponents::TANH:
                         // case FixedPointComponents::TO_FIXEDPOINT:
                         default:
@@ -342,6 +353,24 @@ namespace nil {
                     }
 
                     switch (test.component) {
+                        case FixedPointComponents::ADD: {
+                            using new_component_type = addition<ArithmetizationType, BlueprintFieldType, PolicyType>;
+
+                            // Inputs
+                            typename new_component_type::input_type instance_input {
+                                var(component.W(0), current_row_index, false),
+                                var(component.W(1), current_row_index, false)};
+                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
+                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
+
+                            // Assign component
+                            new_component_type component_instance(witness_list, constant_list, public_input_list);
+                            vars = generate_assignments(component_instance, assignment, instance_input,
+                                                        current_row_index + 1)
+                                       .all_vars();
+                            component_rows = component_instance.rows_amount;
+                            break;
+                        }
                         case FixedPointComponents::ARGMAX: {
                             using new_component_type = fix_argmax<ArithmetizationType, BlueprintFieldType, PolicyType>;
 
@@ -584,6 +613,24 @@ namespace nil {
                         // case FixedPointComponents::SQRT_FLOOR: {
                         //     break;
                         // }
+                        case FixedPointComponents::SUB: {
+                            using new_component_type = subtraction<ArithmetizationType, BlueprintFieldType, PolicyType>;
+
+                            // Inputs
+                            typename new_component_type::input_type instance_input {
+                                var(component.W(0), current_row_index, false),
+                                var(component.W(1), current_row_index, false)};
+                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
+                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
+
+                            // Assign component
+                            new_component_type component_instance(witness_list, constant_list, public_input_list);
+                            vars = generate_assignments(component_instance, assignment, instance_input,
+                                                        current_row_index + 1)
+                                       .all_vars();
+                            component_rows = component_instance.rows_amount;
+                            break;
+                        }
                         // case FixedPointComponents::TANH: {
                         //     break;
                         // }
@@ -639,6 +686,24 @@ namespace nil {
                     auto component_rows = 0;
 
                     switch (test.component) {
+                        case FixedPointComponents::ADD: {
+                            using new_component_type = addition<ArithmetizationType, BlueprintFieldType, PolicyType>;
+
+                            // Inputs
+                            typename new_component_type::input_type instance_input {
+                                var(component.W(0), current_row_index, false),
+                                var(component.W(1), current_row_index, false)};
+                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
+                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
+
+                            // layout component
+                            new_component_type component_instance(witness_list, constant_list, public_input_list);
+                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
+                                                    current_row_index + 1)
+                                       .all_vars();
+                            component_rows = component_instance.rows_amount;
+                            break;
+                        }
                         case FixedPointComponents::ARGMAX: {
                             using new_component_type = fix_argmax<ArithmetizationType, BlueprintFieldType, PolicyType>;
 
@@ -648,6 +713,7 @@ namespace nil {
                                 var(component.W(1), current_row_index, false),
                                 var(component.W(2), current_row_index, false)};
                             BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
+                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 2);
 
                             // layout component
                             bool select_last_index = constants[1] == 0 ? false : true;
@@ -880,6 +946,24 @@ namespace nil {
                         // case FixedPointComponents::SQRT_FLOOR: {
                         //     break;
                         // }
+                        case FixedPointComponents::SUB: {
+                            using new_component_type = subtraction<ArithmetizationType, BlueprintFieldType, PolicyType>;
+
+                            // Inputs
+                            typename new_component_type::input_type instance_input {
+                                var(component.W(0), current_row_index, false),
+                                var(component.W(1), current_row_index, false)};
+                            BLUEPRINT_RELEASE_ASSERT(instance_input.all_vars().size() == inputs.size());
+                            BLUEPRINT_RELEASE_ASSERT(constants.size() == 0);
+
+                            // layout component
+                            new_component_type component_instance(witness_list, constant_list, public_input_list);
+                            vars = generate_circuit(component_instance, bp, assignment, instance_input,
+                                                    current_row_index + 1)
+                                       .all_vars();
+                            component_rows = component_instance.rows_amount;
+                            break;
+                        }
                         // case FixedPointComponents::TANH: {
                         //     break;
                         // }

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp
@@ -441,7 +441,7 @@ namespace nil {
                         instance_input,
                     const std::uint32_t start_row_index) {
 
-                using var = typename plonk_fixedpoint_argmax<BlueprintFieldType, ArithmetizationParams>::var;
+                using var = typename plonk_fixedpoint_tester<BlueprintFieldType, ArithmetizationParams>::var;
                 using ArithmetizationType =
                     crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
                 using PolicyType = nil::blueprint::basic_non_native_policy<BlueprintFieldType>;
@@ -624,7 +624,7 @@ namespace nil {
                     &instance_input,
                 const std::size_t start_row_index) {
 
-                using var = typename plonk_fixedpoint_argmax<BlueprintFieldType, ArithmetizationParams>::var;
+                using var = typename plonk_fixedpoint_tester<BlueprintFieldType, ArithmetizationParams>::var;
                 using ArithmetizationType =
                     crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
                 using PolicyType = nil::blueprint::basic_non_native_policy<BlueprintFieldType>;

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/to_fixedpoint.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/to_fixedpoint.hpp
@@ -126,12 +126,12 @@ namespace nil {
                     var output = var(0, 0, false);
                     result_type(const int_to_fix &component, std::uint32_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     result_type(const int_to_fix &component, std::size_t start_row_index) {
                         const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
-                        output = var(magic(var_pos.y), false);
+                        output = var(splat(var_pos.y), false);
                     }
 
                     std::vector<var> all_vars() const {
@@ -181,8 +181,8 @@ namespace nil {
                 auto x_val = var_value(assignment, instance_input.x);
                 auto y_val = delta * x_val;
 
-                assignment.witness(magic(var_pos.x)) = x_val;
-                assignment.witness(magic(var_pos.y)) = y_val;
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
 
                 return typename plonk_to_fixedpoint<BlueprintFieldType, ArithmetizationParams>::result_type(
                     component, start_row_index);
@@ -203,8 +203,8 @@ namespace nil {
                 using var = typename plonk_to_fixedpoint<BlueprintFieldType, ArithmetizationParams>::var;
                 auto delta = component.get_delta();
 
-                auto x = var(magic(var_pos.x));
-                auto y = var(magic(var_pos.y));
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
 
                 auto constraint = y - x * delta;
 
@@ -238,7 +238,7 @@ namespace nil {
 
                 using var = typename plonk_to_fixedpoint<BlueprintFieldType, ArithmetizationParams>::var;
 
-                auto x = var(magic(var_pos.x), false);
+                auto x = var(splat(var_pos.x), false);
                 bp.add_copy_constraint({instance_input.x, x});
             }
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/tables.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/tables.hpp
@@ -15,6 +15,8 @@ namespace nil {
                 using value_type = typename BlueprintFieldType::value_type;
                 using big_float = nil::crypto3::multiprecision::cpp_bin_float_double;
 
+                static std::vector<value_type> fill_range_table();
+
                 static std::vector<value_type> fill_exp_a_table(uint8_t m2);
                 static std::vector<value_type> fill_exp_b_table(uint8_t m2);
 
@@ -23,9 +25,12 @@ namespace nil {
                 FixedPointTables(const FixedPointTables &) = delete;
                 FixedPointTables &operator=(const FixedPointTables &) = delete;
 
+                static constexpr uint32_t RangeLen = (1ULL << 16);
                 static constexpr uint16_t ExpBScale = 16;
                 static constexpr uint32_t ExpALen = 201;
                 static constexpr uint32_t ExpBLen = (1ULL << ExpBScale);
+
+                static const std::vector<value_type> &get_range_table();
 
                 static const std::vector<value_type> &get_exp_a_16();
                 static const std::vector<value_type> &get_exp_a_32();
@@ -39,6 +44,13 @@ namespace nil {
                 // Highest to still get m2 + m1 limbs
                 static value_type get_highest_valid_exp_input(uint8_t m1, uint8_t m2);
             };
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_range_table() {
+                static std::vector<value_type> range = fill_range_table();
+                return range;
+            }
 
             template<typename BlueprintFieldType>
             const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
@@ -66,6 +78,17 @@ namespace nil {
                 FixedPointTables<BlueprintFieldType>::get_exp_b_32() {
                 static std::vector<value_type> exp_b = fill_exp_b_table(2);
                 return exp_b;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename FixedPointTables<BlueprintFieldType>::value_type>
+                FixedPointTables<BlueprintFieldType>::fill_range_table() {
+                std::vector<value_type> range;
+                range.reserve(RangeLen);
+                for (auto i = 0; i < RangeLen; ++i) {
+                    range.push_back(value_type(i));
+                }
+                return range;
             }
 
             template<typename BlueprintFieldType>

--- a/include/nil/blueprint/components/algebra/fixedpoint/tables.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/tables.hpp
@@ -17,7 +17,6 @@ namespace nil {
 
                 static std::vector<value_type> fill_range_table();
 
-                static std::vector<value_type> fill_exp_a_input();
                 static std::vector<value_type> fill_exp_a_table(uint8_t m2);
                 static std::vector<value_type> fill_exp_b_table(uint8_t m2);
 
@@ -33,7 +32,6 @@ namespace nil {
 
                 static const std::vector<value_type> &get_range_table();
 
-                static const std::vector<value_type> &get_exp_a_input();
                 static const std::vector<value_type> &get_exp_a_16();
                 static const std::vector<value_type> &get_exp_a_32();
                 static const std::vector<value_type> &get_exp_b_16();
@@ -52,13 +50,6 @@ namespace nil {
                 FixedPointTables<BlueprintFieldType>::get_range_table() {
                 static std::vector<value_type> range = fill_range_table();
                 return range;
-            }
-
-            template<typename BlueprintFieldType>
-            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
-                FixedPointTables<BlueprintFieldType>::get_exp_a_input() {
-                static std::vector<value_type> exp_a_inp = fill_exp_a_input();
-                return exp_a_inp;
             }
 
             template<typename BlueprintFieldType>
@@ -98,17 +89,6 @@ namespace nil {
                     range.push_back(value_type(i));
                 }
                 return range;
-            }
-
-            template<typename BlueprintFieldType>
-            std::vector<typename FixedPointTables<BlueprintFieldType>::value_type>
-                FixedPointTables<BlueprintFieldType>::fill_exp_a_input() {
-                std::vector<value_type> exp_a_inp;
-                exp_a_inp.reserve(ExpALen);
-                for (auto i = 0; i < ExpALen; ++i) {
-                    exp_a_inp.push_back(value_type(i));
-                }
-                return exp_a_inp;
             }
 
             template<typename BlueprintFieldType>

--- a/include/nil/blueprint/components/algebra/fixedpoint/tables.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/tables.hpp
@@ -17,6 +17,7 @@ namespace nil {
 
                 static std::vector<value_type> fill_range_table();
 
+                static std::vector<value_type> fill_exp_a_input();
                 static std::vector<value_type> fill_exp_a_table(uint8_t m2);
                 static std::vector<value_type> fill_exp_b_table(uint8_t m2);
 
@@ -32,6 +33,7 @@ namespace nil {
 
                 static const std::vector<value_type> &get_range_table();
 
+                static const std::vector<value_type> &get_exp_a_input();
                 static const std::vector<value_type> &get_exp_a_16();
                 static const std::vector<value_type> &get_exp_a_32();
                 static const std::vector<value_type> &get_exp_b_16();
@@ -50,6 +52,13 @@ namespace nil {
                 FixedPointTables<BlueprintFieldType>::get_range_table() {
                 static std::vector<value_type> range = fill_range_table();
                 return range;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_exp_a_input() {
+                static std::vector<value_type> exp_a_inp = fill_exp_a_input();
+                return exp_a_inp;
             }
 
             template<typename BlueprintFieldType>
@@ -89,6 +98,17 @@ namespace nil {
                     range.push_back(value_type(i));
                 }
                 return range;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename FixedPointTables<BlueprintFieldType>::value_type>
+                FixedPointTables<BlueprintFieldType>::fill_exp_a_input() {
+                std::vector<value_type> exp_a_inp;
+                exp_a_inp.reserve(ExpALen);
+                for (auto i = 0; i < ExpALen; ++i) {
+                    exp_a_inp.push_back(value_type(i));
+                }
+                return exp_a_inp;
             }
 
             template<typename BlueprintFieldType>

--- a/include/nil/blueprint/components/algebra/fixedpoint/tables.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/tables.hpp
@@ -19,6 +19,11 @@ namespace nil {
 
                 static std::vector<value_type> fill_exp_a_table(uint8_t m2);
                 static std::vector<value_type> fill_exp_b_table(uint8_t m2);
+                static std::vector<value_type> fill_sin_a_table(uint8_t m2);    // 2^16*0
+                static std::vector<value_type> fill_sin_b_table(uint8_t m2);    // 2^16*-1
+                static std::vector<value_type> fill_sin_c_table(uint8_t m2);    // 2^16*-2
+                static std::vector<value_type> fill_cos_a_table(uint8_t m2);    // 2^16*0
+                static std::vector<value_type> fill_cos_b_table(uint8_t m2);    // 2^16*-1
 
             public:
                 FixedPointTables() = delete;
@@ -29,13 +34,26 @@ namespace nil {
                 static constexpr uint16_t ExpBScale = 16;
                 static constexpr uint32_t ExpALen = 201;
                 static constexpr uint32_t ExpBLen = (1ULL << ExpBScale);
+                static constexpr uint16_t SinXScale = ExpBScale;
+                static constexpr uint16_t CosXScale = ExpBScale;
+                static constexpr uint32_t SinXLen = (1ULL << SinXScale);
+                static constexpr uint32_t CosXLen = (1ULL << CosXScale);
 
                 static const std::vector<value_type> &get_range_table();
 
                 static const std::vector<value_type> &get_exp_a_16();
+                static const std::vector<value_type> &get_sin_a_16();
+                static const std::vector<value_type> &get_cos_a_16();
                 static const std::vector<value_type> &get_exp_a_32();
+                static const std::vector<value_type> &get_sin_a_32();
+                static const std::vector<value_type> &get_cos_a_32();
                 static const std::vector<value_type> &get_exp_b_16();
+                static const std::vector<value_type> &get_sin_b_16();
+                static const std::vector<value_type> &get_cos_b_16();
                 static const std::vector<value_type> &get_exp_b_32();
+                static const std::vector<value_type> &get_sin_b_32();
+                static const std::vector<value_type> &get_cos_b_32();
+                static const std::vector<value_type> &get_sin_c_32();
 
                 template<uint8_t M2>
                 static constexpr uint16_t get_exp_scale();
@@ -61,9 +79,37 @@ namespace nil {
 
             template<typename BlueprintFieldType>
             const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_sin_a_16() {
+                static std::vector<value_type> sin_a = fill_sin_a_table(1);
+                return sin_a;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_cos_a_16() {
+                static std::vector<value_type> cos_a = fill_cos_a_table(1);
+                return cos_a;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
                 FixedPointTables<BlueprintFieldType>::get_exp_a_32() {
                 static std::vector<value_type> exp_a = fill_exp_a_table(2);
                 return exp_a;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_sin_a_32() {
+                static std::vector<value_type> sin_a = fill_sin_a_table(2);
+                return sin_a;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_cos_a_32() {
+                static std::vector<value_type> cos_a = fill_cos_a_table(2);
+                return cos_a;
             }
 
             template<typename BlueprintFieldType>
@@ -75,9 +121,44 @@ namespace nil {
 
             template<typename BlueprintFieldType>
             const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_sin_b_16() {
+                static std::vector<value_type> sin_b = fill_sin_b_table(1);
+                return sin_b;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_cos_b_16() {
+                static std::vector<value_type> cos_b = fill_cos_b_table(1);
+                return cos_b;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
                 FixedPointTables<BlueprintFieldType>::get_exp_b_32() {
                 static std::vector<value_type> exp_b = fill_exp_b_table(2);
                 return exp_b;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_sin_b_32() {
+                static std::vector<value_type> sin_b = fill_sin_b_table(2);
+                return sin_b;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_cos_b_32() {
+                static std::vector<value_type> cos_b = fill_cos_b_table(2);
+                return cos_b;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_sin_c_32() {
+                static std::vector<value_type> sin_c = fill_sin_c_table(2);
+                return sin_c;
             }
 
             template<typename BlueprintFieldType>
@@ -123,6 +204,86 @@ namespace nil {
                     exp_b.push_back(field_val);
                 }
                 return exp_b;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename FixedPointTables<BlueprintFieldType>::value_type>
+                FixedPointTables<BlueprintFieldType>::fill_sin_a_table(uint8_t m2) {
+                BLUEPRINT_RELEASE_ASSERT(m2 == 1 || m2 == 2);
+                std::vector<value_type> sin_a;
+                sin_a.reserve(SinXLen);
+                for (auto i = 0; i < SinXLen; ++i) {
+                    double val = std::sin(static_cast<double>(i) / (1ULL << SinXScale * 0));
+                    val *= (1ULL << (16 * m2));
+                    auto int_val = int64_t(val);
+                    auto field_val = value_type(int_val);
+                    sin_a.push_back(field_val);
+                }
+                return sin_a;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename FixedPointTables<BlueprintFieldType>::value_type>
+                FixedPointTables<BlueprintFieldType>::fill_sin_b_table(uint8_t m2) {
+                BLUEPRINT_RELEASE_ASSERT(m2 == 1 || m2 == 2);
+                std::vector<value_type> sin_b;
+                sin_b.reserve(SinXLen);
+                for (auto i = 0; i < SinXLen; ++i) {
+                    double val = std::sin(static_cast<double>(i) / (1ULL << SinXScale * 1));
+                    val *= (1ULL << (16 * m2));
+                    auto int_val = uint64_t(val);
+                    auto field_val = value_type(int_val);
+                    sin_b.push_back(field_val);
+                }
+                return sin_b;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename FixedPointTables<BlueprintFieldType>::value_type>
+                FixedPointTables<BlueprintFieldType>::fill_sin_c_table(uint8_t m2) {
+                BLUEPRINT_RELEASE_ASSERT(m2 == 2);
+                std::vector<value_type> sin_c;
+                sin_c.reserve(SinXLen);
+                for (auto i = 0; i < SinXLen; ++i) {
+                    double val = std::sin(static_cast<double>(i) / (1ULL << SinXScale * 2));
+                    val *= (1ULL << (16 * m2));
+                    auto int_val = uint64_t(val);
+                    auto field_val = value_type(int_val);
+                    sin_c.push_back(field_val);
+                }
+                return sin_c;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename FixedPointTables<BlueprintFieldType>::value_type>
+                FixedPointTables<BlueprintFieldType>::fill_cos_a_table(uint8_t m2) {
+                BLUEPRINT_RELEASE_ASSERT(m2 == 1 || m2 == 2);
+                std::vector<value_type> cos_a;
+                cos_a.reserve(CosXLen);
+                for (auto i = 0; i < CosXLen; ++i) {
+                    double val = std::cos(static_cast<double>(i) / (1ULL << CosXScale * 0));
+                    val *= (1ULL << (16 * m2));
+                    auto int_val = int64_t(val);
+                    auto field_val = value_type(int_val);
+                    cos_a.push_back(field_val);
+                }
+                return cos_a;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename FixedPointTables<BlueprintFieldType>::value_type>
+                FixedPointTables<BlueprintFieldType>::fill_cos_b_table(uint8_t m2) {
+                BLUEPRINT_RELEASE_ASSERT(m2 == 1 || m2 == 2);
+                std::vector<value_type> cos_b;
+                cos_b.reserve(CosXLen);
+                for (auto i = 0; i < CosXLen; ++i) {
+                    double val = std::cos(static_cast<double>(i) / (1ULL << CosXScale * 1));
+                    val *= (1ULL << (16 * m2));
+                    auto int_val = uint64_t(val);
+                    auto field_val = value_type(int_val);
+                    cos_b.push_back(field_val);
+                }
+                return cos_b;
             }
 
             template<typename BlueprintFieldType>

--- a/include/nil/blueprint/components/algebra/fixedpoint/type.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/type.hpp
@@ -647,17 +647,24 @@ namespace nil {
                 auto cos_b = M2 == 1 ? FixedPointTables<BlueprintFieldType>::get_cos_b_16() :
                                        FixedPointTables<BlueprintFieldType>::get_cos_b_32();
 
-                constexpr auto two_pi = M2 == 1 ? typename BlueprintFieldType::value_type(411775ULL) :
-                                                  typename BlueprintFieldType::value_type(26986075409ULL);
+                constexpr auto two_pi = typename BlueprintFieldType::value_type(26986075409ULL);
 
                 std::vector<uint16_t> x0_val;
                 auto reduced_val = value;    // x_reduced guarantees the use of only one pre-comma limb
                 if (M1 == 2) {               // if two pre-comma limbs are used, x is reduced mod 2*pi
-                    reduced_val = FixedPointHelper<BlueprintFieldType>::div_mod(value, two_pi).remainder;
+                    if (M2 == 2) {
+                        reduced_val = FixedPointHelper<BlueprintFieldType>::div_mod(value, two_pi).remainder;
+                    } else {    // case fixedpoint 32.16: use 32 post comma bits (2 limbs) for better precision
+                        reduced_val = FixedPointHelper<BlueprintFieldType>::div_mod(value * delta, two_pi).remainder;
+                    }
                 }
                 bool sign = FixedPointHelper<BlueprintFieldType>::decompose(reduced_val, x0_val);
                 if (M1 == 2) {
                     BLUEPRINT_RELEASE_ASSERT(!sign);
+                }
+                // case fixedpoint 32.16: trash the smallest limb, as the result has one post comma limb only
+                if (M1 == 2 && M2 == 1) {
+                    x0_val.erase(x0_val.begin());
                 }
                 BLUEPRINT_RELEASE_ASSERT(x0_val.size() >= M2 + 1);
                 auto sign_val = sign ? -one : one;
@@ -694,17 +701,24 @@ namespace nil {
                 auto cos_b = M2 == 1 ? FixedPointTables<BlueprintFieldType>::get_cos_b_16() :
                                        FixedPointTables<BlueprintFieldType>::get_cos_b_32();
 
-                constexpr auto two_pi = M2 == 1 ? typename BlueprintFieldType::value_type(411775ULL) :
-                                                  typename BlueprintFieldType::value_type(26986075409ULL);
+                constexpr auto two_pi = typename BlueprintFieldType::value_type(26986075409ULL);
 
                 std::vector<uint16_t> x0_val;
                 auto reduced_val = value;    // x_reduced guarantees the use of only one pre-comma limb
                 if (M1 == 2) {               // if two pre-comma limbs are used, x is reduced mod 2*pi
-                    reduced_val = FixedPointHelper<BlueprintFieldType>::div_mod(value, two_pi).remainder;
+                    if (M2 == 2) {
+                        reduced_val = FixedPointHelper<BlueprintFieldType>::div_mod(value, two_pi).remainder;
+                    } else {    // case fixedpoint 32.16: use 32 post comma bits (2 limbs) for better precision
+                        reduced_val = FixedPointHelper<BlueprintFieldType>::div_mod(value * delta, two_pi).remainder;
+                    }
                 }
                 bool sign = FixedPointHelper<BlueprintFieldType>::decompose(reduced_val, x0_val);
                 if (M1 == 2) {
                     BLUEPRINT_RELEASE_ASSERT(!sign);
+                }
+                // case fixedpoint 32.16: trash the smallest limb, as the result has one post comma limb only
+                if (M1 == 2 && M2 == 1) {
+                    x0_val.erase(x0_val.begin());
                 }
                 BLUEPRINT_RELEASE_ASSERT(x0_val.size() >= M2 + 1);
 

--- a/include/nil/blueprint/components/algebra/fixedpoint/type.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/type.hpp
@@ -11,7 +11,7 @@
 #include <nil/crypto3/multiprecision/detail/default_ops.hpp>
 
 // macro for getting a variable list from a cell position for fixedpoint components
-#define magic(x) x.column(), x.row()
+#define splat(x) x.column(), x.row()
 
 namespace nil {
     namespace blueprint {

--- a/include/nil/blueprint/components/algebra/fixedpoint/type.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/type.hpp
@@ -163,6 +163,10 @@ namespace nil {
             using FixedPoint16_16 = FixedPoint<BlueprintFieldType, 1, 1>;
             template<typename BlueprintFieldType>
             using FixedPoint32_32 = FixedPoint<BlueprintFieldType, 2, 2>;
+            template<typename BlueprintFieldType>
+            using FixedPoint16_32 = FixedPoint<BlueprintFieldType, 1, 2>;
+            template<typename BlueprintFieldType>
+            using FixedPoint32_16 = FixedPoint<BlueprintFieldType, 2, 1>;
 
             template<typename BlueprintFieldType>
             typename FixedPointHelper<BlueprintFieldType>::modular_backend

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -191,6 +191,7 @@ SET(FIXEDPOINT_TESTS_FILES
     "algebra/fixedpoint/plonk/cmp"
     "algebra/fixedpoint/plonk/ml"
     "algebra/fixedpoint/plonk/advanced_operations"
+    "algebra/fixedpoint/plonk/tester"
 )
 
 SET(ALGEBRA_TESTS_FILES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -193,6 +193,7 @@ SET(FIXEDPOINT_TESTS_FILES
     "algebra/fixedpoint/plonk/advanced_operations"
     "algebra/fixedpoint/plonk/tester"
     "algebra/fixedpoint/plonk/trigonometric"
+    "algebra/fixedpoint/plonk/boolean"
 )
 
 SET(ALGEBRA_TESTS_FILES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -192,6 +192,7 @@ SET(FIXEDPOINT_TESTS_FILES
     "algebra/fixedpoint/plonk/ml"
     "algebra/fixedpoint/plonk/advanced_operations"
     "algebra/fixedpoint/plonk/tester"
+    "algebra/fixedpoint/plonk/trigonometric"
 )
 
 SET(ALGEBRA_TESTS_FILES

--- a/test/algebra/fixedpoint/plonk/advanced_operations.cpp
+++ b/test/algebra/fixedpoint/plonk/advanced_operations.cpp
@@ -1,5 +1,8 @@
 #define BOOST_TEST_MODULE blueprint_plonk_fixedpoint_advanced_operations_test
 
+// Enable for faster tests
+// #define TEST_WITHOUT_LOOKUP_TABLES
+
 #include <boost/test/unit_test.hpp>
 
 #include <nil/crypto3/algebra/fields/bls12/scalar_field.hpp>
@@ -39,8 +42,8 @@ void test_fixedpoint_sqrt(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 15;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 0;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -97,8 +100,8 @@ void test_fixedpoint_sqrt_floor(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 10;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 0;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;

--- a/test/algebra/fixedpoint/plonk/advanced_operations.cpp
+++ b/test/algebra/fixedpoint/plonk/advanced_operations.cpp
@@ -160,8 +160,8 @@ void test_fixedpoint_log(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 10;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 5;
-    constexpr std::size_t SelectorColumns = 5;
+    constexpr std::size_t ConstantColumns = 10;
+    constexpr std::size_t SelectorColumns = 10;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;

--- a/test/algebra/fixedpoint/plonk/advanced_operations.cpp
+++ b/test/algebra/fixedpoint/plonk/advanced_operations.cpp
@@ -160,8 +160,8 @@ void test_fixedpoint_log(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 10;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 2;
-    constexpr std::size_t SelectorColumns = 3;
+    constexpr std::size_t ConstantColumns = 5;
+    constexpr std::size_t SelectorColumns = 5;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;

--- a/test/algebra/fixedpoint/plonk/basic_operations.cpp
+++ b/test/algebra/fixedpoint/plonk/basic_operations.cpp
@@ -154,8 +154,8 @@ void test_fixedpoint_rescale(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 2 + FixedType::M_2;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 0;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -180,7 +180,7 @@ void test_fixedpoint_rescale(FixedType input) {
         auto real_res_ = FixedType(var_value(assignment, real_res.output), FixedType::SCALE);
         double real_res_f = real_res_.to_double();
 #ifdef BLUEPRINT_PLONK_PROFILING_ENABLED
-        std::cout << "fixed_point mul test: "
+        std::cout << "fixed_point rescale test: "
                   << "\n";
         std::cout << "input_f : " << input.to_double() << "\n";
         std::cout << "input   : " << input.get_value().data << "\n";

--- a/test/algebra/fixedpoint/plonk/basic_operations.cpp
+++ b/test/algebra/fixedpoint/plonk/basic_operations.cpp
@@ -462,7 +462,7 @@ void test_fixedpoint_mod(FixedType input1, FixedType input2) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 15;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t ConstantColumns = 3;
     constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
@@ -507,16 +507,19 @@ void test_fixedpoint_mod(FixedType input1, FixedType input2) {
             abort();
         }
     };
-
+ 
     std::vector<std::uint32_t> witness_list;
     witness_list.reserve(WitnessColumns);
     for (auto i = 0; i < WitnessColumns; i++) {
         witness_list.push_back(i);
     }
     // Is done by the manifest in a real circuit
-    component_type component_instance(
-        witness_list, std::array<std::uint32_t, 0>(), std::array<std::uint32_t, 0>(), FixedType::M_1, FixedType::M_2);
-
+    component_type component_instance(witness_list,
+                                      std::array<std::uint32_t, 1>({0}),
+                                      std::array<std::uint32_t, 0>(),
+                                      FixedType::M_1,
+                                      FixedType::M_2);
+ 
     std::vector<typename BlueprintFieldType::value_type> public_input = {input1.get_value(), input2.get_value()};
     nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
         component_instance, public_input, result_check, instance_input);

--- a/test/algebra/fixedpoint/plonk/basic_operations.cpp
+++ b/test/algebra/fixedpoint/plonk/basic_operations.cpp
@@ -278,8 +278,8 @@ void test_fixedpoint_mul_rescale(FixedType input1, FixedType input2) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 3 + FixedType::M_2;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 0;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -579,8 +579,8 @@ void test_fixedpoint_mul_rescale_const(FixedType priv_input, FixedType const_inp
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 2 + FixedType::M_2;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 1;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 3;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;

--- a/test/algebra/fixedpoint/plonk/basic_operations.cpp
+++ b/test/algebra/fixedpoint/plonk/basic_operations.cpp
@@ -462,8 +462,8 @@ void test_fixedpoint_mod(FixedType input1, FixedType input2) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 15;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 0;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;

--- a/test/algebra/fixedpoint/plonk/basic_operations.cpp
+++ b/test/algebra/fixedpoint/plonk/basic_operations.cpp
@@ -340,8 +340,8 @@ void test_fixedpoint_div(FixedType input1, FixedType input2) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 15;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 0;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -400,8 +400,8 @@ void test_fixedpoint_div_by_pos(FixedType input1, FixedType input2) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 10;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 0;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;

--- a/test/algebra/fixedpoint/plonk/basic_operations.cpp
+++ b/test/algebra/fixedpoint/plonk/basic_operations.cpp
@@ -1,5 +1,8 @@
 #define BOOST_TEST_MODULE blueprint_plonk_fixedpoint_basic_test
 
+// Enable for faster tests
+// #define TEST_WITHOUT_LOOKUP_TABLES
+
 #include <boost/test/unit_test.hpp>
 
 #include <nil/crypto3/algebra/fields/bls12/scalar_field.hpp>

--- a/test/algebra/fixedpoint/plonk/boolean.cpp
+++ b/test/algebra/fixedpoint/plonk/boolean.cpp
@@ -29,15 +29,19 @@ using nil::blueprint::components::FixedPoint32_32;
 
 static constexpr double EPSILON = 0.01;
 
-#define PRINT_FIXED_POINT_TEST(what)                                          \
-    std::cout << "fixed_point " << what << " test:\n";                        \
-    std::cout << "a                : " << a.get_value().data << "\n";         \
-    std::cout << "b                : " << b.get_value().data << "\n";         \
-    std::cout << "expected and     : " << and_.get_value().data << "\n";      \
-    std::cout << "real and         : " << real_and_.get_value().data << "\n"; \
-    std::cout << "expected or      : " << or_.get_value().data << "\n";       \
-    std::cout << "real or          : " << real_or_.get_value().data << "\n";  \
-    std::cout << "expected xor     : " << xor_.get_value().data << "\n";      \
+#define PRINT_FIXED_POINT_TEST(what)                                            \
+    std::cout << "fixed_point " << what << " test:\n";                          \
+    std::cout << "a                : " << a.get_value().data << "\n";           \
+    std::cout << "b                : " << b.get_value().data << "\n";           \
+    std::cout << "expected a_inv   : " << a_inv_.get_value().data << "\n";      \
+    std::cout << "real a_inv       : " << real_a_inv_.get_value().data << "\n"; \
+    std::cout << "expected b_inv   : " << b_inv_.get_value().data << "\n";      \
+    std::cout << "real b_inv       : " << real_b_inv_.get_value().data << "\n"; \
+    std::cout << "expected and     : " << and_.get_value().data << "\n";        \
+    std::cout << "real and         : " << real_and_.get_value().data << "\n";   \
+    std::cout << "expected or      : " << or_.get_value().data << "\n";         \
+    std::cout << "real or          : " << real_or_.get_value().data << "\n";    \
+    std::cout << "expected xor     : " << xor_.get_value().data << "\n";        \
     std::cout << "real xor         : " << real_xor_.get_value().data << "\n";
 
 bool doubleEquals(double a, double b, double epsilon) {
@@ -50,7 +54,7 @@ bool doubleEquals(double a, double b, double epsilon) {
 template<typename FixedType>
 void test_fixedpoint_boolean(FixedType a, FixedType b) {
     using BlueprintFieldType = typename FixedType::field_type;
-    constexpr std::size_t WitnessColumns = 5;
+    constexpr std::size_t WitnessColumns = 7;
     constexpr std::size_t PublicInputColumns = 1;
 #ifdef TEST_WITHOUT_LOOKUP_TABLES
     constexpr std::size_t ConstantColumns = 0;
@@ -83,17 +87,22 @@ void test_fixedpoint_boolean(FixedType a, FixedType b) {
     auto and_ = a == one && b == one ? one : zero;
     auto or_ = a == one ? a : b;
     auto xor_ = a == b ? zero : one;
+    auto a_inv_ = a == one ? zero : one;
+    auto b_inv_ = b == one ? zero : one;
     // the above is true for a, b in {0, 1}. Other values are caught by lookup tables
 
-    auto result_check = [&and_, &or_, &xor_, &a, &b](AssignmentType &assignment,
-                                                     typename component_type::result_type &real_res) {
+    auto result_check = [&and_, &or_, &xor_, &a_inv_, &b_inv_, &a, &b](AssignmentType &assignment,
+                                                                       typename component_type::result_type &real_res) {
         auto real_and_ = FixedType(var_value(assignment, real_res.and_), FixedType::SCALE);
         auto real_or_ = FixedType(var_value(assignment, real_res.or_), FixedType::SCALE);
         auto real_xor_ = FixedType(var_value(assignment, real_res.xor_), FixedType::SCALE);
+        auto real_a_inv_ = FixedType(var_value(assignment, real_res.a_inv_), FixedType::SCALE);
+        auto real_b_inv_ = FixedType(var_value(assignment, real_res.b_inv_), FixedType::SCALE);
 #ifdef BLUEPRINT_PLONK_PROFILING_ENABLED
         PRINT_FIXED_POINT_TEST("boolean")
 #endif
-        if (real_and_ != and_ || real_or_ != or_ || real_xor_ != xor_) {
+        if (real_and_ != and_ || real_or_ != or_ || real_xor_ != xor_ || real_a_inv_ != a_inv_ ||
+            real_b_inv_ != b_inv_) {
             PRINT_FIXED_POINT_TEST("boolean")
             abort();
         }

--- a/test/algebra/fixedpoint/plonk/boolean.cpp
+++ b/test/algebra/fixedpoint/plonk/boolean.cpp
@@ -1,0 +1,152 @@
+#define BOOST_TEST_MODULE blueprint_plonk_fixedpoint_trigonometric_operations_test
+
+// Enable for faster tests
+// #define TEST_WITHOUT_LOOKUP_TABLES
+
+#include <boost/test/unit_test.hpp>
+
+#include <nil/crypto3/algebra/fields/bls12/scalar_field.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/bls12.hpp>
+#include <nil/crypto3/algebra/curves/vesta.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/vesta.hpp>
+#include <nil/crypto3/algebra/curves/pallas.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/pallas.hpp>
+
+#include <nil/crypto3/hash/keccak.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <boost/random/mersenne_twister.hpp>
+
+#include <nil/blueprint/blueprint/plonk/assignment.hpp>
+#include <nil/blueprint/blueprint/plonk/circuit.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/type.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/plonk/boolean.hpp>
+
+#include "../../../test_plonk_component.hpp"
+
+using namespace nil;
+using nil::blueprint::components::FixedPoint16_16;
+using nil::blueprint::components::FixedPoint32_32;
+
+static constexpr double EPSILON = 0.01;
+
+#define PRINT_FIXED_POINT_TEST(what)                                          \
+    std::cout << "fixed_point " << what << " test:\n";                        \
+    std::cout << "a                : " << a.get_value().data << "\n";         \
+    std::cout << "b                : " << b.get_value().data << "\n";         \
+    std::cout << "expected and     : " << and_.get_value().data << "\n";      \
+    std::cout << "real and         : " << real_and_.get_value().data << "\n"; \
+    std::cout << "expected or      : " << or_.get_value().data << "\n";       \
+    std::cout << "real or          : " << real_or_.get_value().data << "\n";  \
+    std::cout << "expected xor     : " << xor_.get_value().data << "\n";      \
+    std::cout << "real xor         : " << real_xor_.get_value().data << "\n";
+
+bool doubleEquals(double a, double b, double epsilon) {
+    // Essentially equal from
+    // https://stackoverflow.com/questions/17333/how-do-you-compare-float-and-double-while-accounting-for-precision-loss
+    // or just smaller epsilon
+    return fabs(a - b) < epsilon || fabs(a - b) <= ((fabs(a) > fabs(b) ? fabs(b) : fabs(a)) * epsilon);
+}
+
+template<typename FixedType>
+void test_fixedpoint_boolean(FixedType a, FixedType b) {
+    using BlueprintFieldType = typename FixedType::field_type;
+    constexpr std::size_t WitnessColumns = 5;
+    constexpr std::size_t PublicInputColumns = 1;
+#ifdef TEST_WITHOUT_LOOKUP_TABLES
+    constexpr std::size_t ConstantColumns = 0;
+    constexpr std::size_t SelectorColumns = 1;
+#else
+    constexpr std::size_t ConstantColumns = 15;
+    constexpr std::size_t SelectorColumns = 15;
+#endif
+    using ArithmetizationParams = crypto3::zk::snark::
+        plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
+    using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
+    using hash_type = nil::crypto3::hashes::keccak_1600<256>;
+    constexpr std::size_t Lambda = 40;
+    using AssignmentType = nil::blueprint::assignment<ArithmetizationType>;
+
+    using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
+
+    using component_type =
+        blueprint::components::fix_boolean<ArithmetizationType,
+                                           BlueprintFieldType,
+                                           nil::blueprint::basic_non_native_policy<BlueprintFieldType>>;
+
+    typename component_type::input_type instance_input = {var(0, 0, false, var::column_type::public_input),
+                                                          var(0, 1, false, var::column_type::public_input)};
+
+    using value_type = typename FixedType::value_type;
+    auto zero = FixedType(value_type(0), FixedType::SCALE);
+    auto one = FixedType(value_type(1), FixedType::SCALE);
+
+    auto and_ = a == one && b == one ? one : zero;
+    auto or_ = a == one ? a : b;
+    auto xor_ = a == b ? zero : one;
+    // the above is true for a, b in {0, 1}. Other values are caught by lookup tables
+
+    auto result_check = [&and_, &or_, &xor_, &a, &b](AssignmentType &assignment,
+                                                     typename component_type::result_type &real_res) {
+        auto real_and_ = FixedType(var_value(assignment, real_res.and_), FixedType::SCALE);
+        auto real_or_ = FixedType(var_value(assignment, real_res.or_), FixedType::SCALE);
+        auto real_xor_ = FixedType(var_value(assignment, real_res.xor_), FixedType::SCALE);
+#ifdef BLUEPRINT_PLONK_PROFILING_ENABLED
+        PRINT_FIXED_POINT_TEST("boolean")
+#endif
+        if (real_and_ != and_ || real_or_ != or_ || real_xor_ != xor_) {
+            PRINT_FIXED_POINT_TEST("boolean")
+            abort();
+        }
+    };
+
+    std::vector<std::uint32_t> witness_list;
+    witness_list.reserve(WitnessColumns);
+    for (auto i = 0; i < WitnessColumns; i++) {
+        witness_list.push_back(i);
+    }
+    std::vector<std::uint32_t> const_list;
+    const_list.reserve(ConstantColumns);
+    for (auto i = 0; i < ConstantColumns; i++) {
+        const_list.push_back(i);
+    }
+    // Is done by the manifest in a real circuit
+    component_type component_instance(
+        witness_list, const_list, std::array<std::uint32_t, 0>(), FixedType::M_1, FixedType::M_2);
+
+    std::vector<typename BlueprintFieldType::value_type> public_input = {a.get_value(), b.get_value()};
+    nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
+        component_instance, public_input, result_check, instance_input);
+}
+
+template<typename FixedType>
+void field_operations_test() {
+    using value_type = typename FixedType::value_type;
+    auto zero = FixedType(value_type(0), FixedType::SCALE);
+    auto one = FixedType(value_type(1), FixedType::SCALE);
+    test_fixedpoint_boolean(zero, zero);
+    test_fixedpoint_boolean(zero, one);
+    test_fixedpoint_boolean(one, zero);
+    test_fixedpoint_boolean(one, one);
+}
+
+BOOST_AUTO_TEST_SUITE(blueprint_plonk_test_suite)
+
+BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_trigonometric_test_vesta) {
+    using field_type = typename crypto3::algebra::curves::vesta::base_field_type;
+    field_operations_test<FixedPoint16_16<field_type>>();
+    field_operations_test<FixedPoint32_32<field_type>>();
+}
+
+BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_trigonometric_test_pallas) {
+    using field_type = typename crypto3::algebra::curves::pallas::base_field_type;
+    field_operations_test<FixedPoint16_16<field_type>>();
+    field_operations_test<FixedPoint32_32<field_type>>();
+}
+
+BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_trigonometric_test_bls12) {
+    using field_type = typename crypto3::algebra::fields::bls12_fr<381>;
+    field_operations_test<FixedPoint16_16<field_type>>();
+    field_operations_test<FixedPoint32_32<field_type>>();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/algebra/fixedpoint/plonk/cmp.cpp
+++ b/test/algebra/fixedpoint/plonk/cmp.cpp
@@ -340,8 +340,8 @@ void test_fixedpoint_max(FixedType input1, FixedType input2) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 5 + FixedType::M_1 + FixedType::M_2;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 0;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -402,8 +402,8 @@ void test_fixedpoint_min(FixedType input1, FixedType input2) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 5 + FixedType::M_1 + FixedType::M_2;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 0;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -585,8 +585,8 @@ void test_fixedpoint_range(FixedType input, FixedType x_lo, FixedType x_hi) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 16;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 2;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 4;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;

--- a/test/algebra/fixedpoint/plonk/cmp.cpp
+++ b/test/algebra/fixedpoint/plonk/cmp.cpp
@@ -669,9 +669,8 @@ void test_fixedpoint_range(FixedType input, FixedType x_lo, FixedType x_hi) {
         witness_list.push_back(i);
     }
     // Is done by the manifest in a real circuit
-    // constant columns 1 and 2 are used by the lookup table
     component_type component_instance(witness_list,
-                                      std::array<std::uint32_t, 2>({0, 3}),
+                                      std::array<std::uint32_t, 2>({0, 1}),
                                       std::array<std::uint32_t, 0>(),
                                       FixedType::M_1,
                                       FixedType::M_2,

--- a/test/algebra/fixedpoint/plonk/cmp.cpp
+++ b/test/algebra/fixedpoint/plonk/cmp.cpp
@@ -669,8 +669,9 @@ void test_fixedpoint_range(FixedType input, FixedType x_lo, FixedType x_hi) {
         witness_list.push_back(i);
     }
     // Is done by the manifest in a real circuit
+    // constant columns 1 and 2 are used by the lookup table
     component_type component_instance(witness_list,
-                                      std::array<std::uint32_t, 2>({0, 1}),
+                                      std::array<std::uint32_t, 2>({0, 3}),
                                       std::array<std::uint32_t, 0>(),
                                       FixedType::M_1,
                                       FixedType::M_2,

--- a/test/algebra/fixedpoint/plonk/cmp.cpp
+++ b/test/algebra/fixedpoint/plonk/cmp.cpp
@@ -1,5 +1,8 @@
 #define BOOST_TEST_MODULE blueprint_plonk_fixedpoint_cmp_test
 
+// Enable for faster tests
+// #define TEST_WITHOUT_LOOKUP_TABLES
+
 #include <boost/test/unit_test.hpp>
 
 #include <nil/crypto3/algebra/fields/bls12/scalar_field.hpp>
@@ -43,8 +46,8 @@ void test_fixedpoint_cmp(FixedType input1, FixedType input2) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 8 + FixedType::M_1 + FixedType::M_2;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 0;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -132,8 +135,8 @@ void test_fixedpoint_cmp_extended(FixedType input1, FixedType input2) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 11 + FixedType::M_1 + FixedType::M_2;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 0;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -461,8 +464,8 @@ void test_fixedpoint_cmp_min_max(FixedType input1, FixedType input2) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 10 + FixedType::M_1 + FixedType::M_2;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 0;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;

--- a/test/algebra/fixedpoint/plonk/dot_rescale.cpp
+++ b/test/algebra/fixedpoint/plonk/dot_rescale.cpp
@@ -1,5 +1,8 @@
 #define BOOST_TEST_MODULE blueprint_plonk_fixedpoint_dot_test
 
+// Enable for faster tests
+// #define TEST_WITHOUT_LOOKUP_TABLES
+
 #include <boost/test/unit_test.hpp>
 
 #include <nil/crypto3/algebra/fields/bls12/scalar_field.hpp>
@@ -41,8 +44,8 @@ void test_fixedpoint_dot_1_gate(std::vector<FixedType> &input1, std::vector<Fixe
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 8;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 0;
-    constexpr std::size_t SelectorColumns = 2;
+    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t SelectorColumns = 4;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -120,8 +123,8 @@ void test_fixedpoint_dot_2_gates(std::vector<FixedType> &input1, std::vector<Fix
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 7;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 0;
-    constexpr std::size_t SelectorColumns = 3;
+    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t SelectorColumns = 5;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;

--- a/test/algebra/fixedpoint/plonk/dot_rescale.cpp
+++ b/test/algebra/fixedpoint/plonk/dot_rescale.cpp
@@ -46,8 +46,8 @@ void test_fixedpoint_dot_1_gate(std::vector<FixedType> &input1, std::vector<Fixe
     constexpr std::size_t PublicInputColumns = 1;
     constexpr std::size_t ConstantColumns = 2;
     constexpr std::size_t SelectorColumns = 4;
-    using ArithmetizationParams = crypto3::zk::snark::
-        plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
+    using ArithmetizationParams = crypto3::zk::snark::plonk_arithmetization_params<WitnessColumns, PublicInputColumns,
+                                                                                   ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
     using hash_type = nil::crypto3::hashes::keccak_1600<256>;
     constexpr std::size_t Lambda = 40;
@@ -56,8 +56,7 @@ void test_fixedpoint_dot_1_gate(std::vector<FixedType> &input1, std::vector<Fixe
     using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
 
     using component_type =
-        blueprint::components::fix_dot_rescale_1_gate<ArithmetizationType,
-                                                      BlueprintFieldType,
+        blueprint::components::fix_dot_rescale_1_gate<ArithmetizationType, BlueprintFieldType,
                                                       nil::blueprint::basic_non_native_policy<BlueprintFieldType>>;
 
     std::vector<var> instance_input_x;
@@ -83,8 +82,8 @@ void test_fixedpoint_dot_1_gate(std::vector<FixedType> &input1, std::vector<Fixe
     }
     auto expected_res = FixedType::dot(input1, input2);
 
-    auto result_check = [&expected_res, &expected_res_f, input1, input2](
-                            AssignmentType &assignment, typename component_type::result_type &real_res) {
+    auto result_check = [&expected_res, &expected_res_f, input1,
+                         input2](AssignmentType &assignment, typename component_type::result_type &real_res) {
         auto real_res_ = FixedType(var_value(assignment, real_res.output), FixedType::SCALE);
         double real_res_f = real_res_.to_double();
 #ifdef BLUEPRINT_PLONK_PROFILING_ENABLED
@@ -109,11 +108,16 @@ void test_fixedpoint_dot_1_gate(std::vector<FixedType> &input1, std::vector<Fixe
         witness_list.push_back(i);
     }
     // Is done by the manifest in a real circuit
-    component_type component_instance(
-        witness_list, std::array<std::uint32_t, 0>(), std::array<std::uint32_t, 0>(), dots, FixedType::M_2);
+    component_type component_instance(witness_list, std::array<std::uint32_t, 0>(), std::array<std::uint32_t, 0>(),
+                                      dots, FixedType::M_2);
 
     nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
-        component_instance, public_input, result_check, instance_input);
+        component_instance,
+        public_input,
+        result_check,
+        instance_input,
+        crypto3::detail::connectedness_check_type::NONE);
+    // The zero is sometimes not connected
 }
 
 template<typename FixedType>
@@ -125,8 +129,8 @@ void test_fixedpoint_dot_2_gates(std::vector<FixedType> &input1, std::vector<Fix
     constexpr std::size_t PublicInputColumns = 1;
     constexpr std::size_t ConstantColumns = 2;
     constexpr std::size_t SelectorColumns = 5;
-    using ArithmetizationParams = crypto3::zk::snark::
-        plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
+    using ArithmetizationParams = crypto3::zk::snark::plonk_arithmetization_params<WitnessColumns, PublicInputColumns,
+                                                                                   ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
     using hash_type = nil::crypto3::hashes::keccak_1600<256>;
     constexpr std::size_t Lambda = 40;
@@ -135,8 +139,7 @@ void test_fixedpoint_dot_2_gates(std::vector<FixedType> &input1, std::vector<Fix
     using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
 
     using component_type =
-        blueprint::components::fix_dot_rescale_2_gates<ArithmetizationType,
-                                                       BlueprintFieldType,
+        blueprint::components::fix_dot_rescale_2_gates<ArithmetizationType, BlueprintFieldType,
                                                        nil::blueprint::basic_non_native_policy<BlueprintFieldType>>;
 
     std::vector<var> instance_input_x;
@@ -162,8 +165,8 @@ void test_fixedpoint_dot_2_gates(std::vector<FixedType> &input1, std::vector<Fix
     }
     auto expected_res = FixedType::dot(input1, input2);
 
-    auto result_check = [&expected_res, &expected_res_f, input1, input2](
-                            AssignmentType &assignment, typename component_type::result_type &real_res) {
+    auto result_check = [&expected_res, &expected_res_f, input1,
+                         input2](AssignmentType &assignment, typename component_type::result_type &real_res) {
         auto real_res_ = FixedType(var_value(assignment, real_res.output), FixedType::SCALE);
         double real_res_f = real_res_.to_double();
 #ifdef BLUEPRINT_PLONK_PROFILING_ENABLED
@@ -188,11 +191,16 @@ void test_fixedpoint_dot_2_gates(std::vector<FixedType> &input1, std::vector<Fix
         witness_list.push_back(i);
     }
     // Is done by the manifest in a real circuit
-    component_type component_instance(
-        witness_list, std::array<std::uint32_t, 0>(), std::array<std::uint32_t, 0>(), dots, FixedType::M_2);
+    component_type component_instance(witness_list, std::array<std::uint32_t, 0>(), std::array<std::uint32_t, 0>(),
+                                      dots, FixedType::M_2);
 
     nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
-        component_instance, public_input, result_check, instance_input);
+        component_instance,
+        public_input,
+        result_check,
+        instance_input,
+        crypto3::detail::connectedness_check_type::NONE);
+    // The zero is sometimes not connected
 }
 
 template<typename FieldType, typename RngType>

--- a/test/algebra/fixedpoint/plonk/exp.cpp
+++ b/test/algebra/fixedpoint/plonk/exp.cpp
@@ -43,8 +43,8 @@ void test_fixedpoint_exp(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 6 + 2 * FixedType::M_2;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 5;
-    constexpr std::size_t SelectorColumns = 5;
+    constexpr std::size_t ConstantColumns = 10;
+    constexpr std::size_t SelectorColumns = 10;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -102,8 +102,8 @@ void test_fixedpoint_exp_ranged(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 16;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 5;
-    constexpr std::size_t SelectorColumns = 5;
+    constexpr std::size_t ConstantColumns = 10;
+    constexpr std::size_t SelectorColumns = 10;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -179,7 +179,7 @@ void test_fixedpoint_tanh(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 16;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 5;
+    constexpr std::size_t ConstantColumns = 10;
     constexpr std::size_t SelectorColumns = 10;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;

--- a/test/algebra/fixedpoint/plonk/exp.cpp
+++ b/test/algebra/fixedpoint/plonk/exp.cpp
@@ -1,5 +1,8 @@
 #define BOOST_TEST_MODULE blueprint_plonk_fixedpoint_exp_test
 
+// Enable for faster tests
+// #define TEST_WITHOUT_LOOKUP_TABLES
+
 #include <boost/test/unit_test.hpp>
 
 #include <nil/crypto3/algebra/fields/bls12/scalar_field.hpp>
@@ -40,8 +43,8 @@ void test_fixedpoint_exp(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 6 + 2 * FixedType::M_2;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 0;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 2;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;

--- a/test/algebra/fixedpoint/plonk/exp.cpp
+++ b/test/algebra/fixedpoint/plonk/exp.cpp
@@ -43,8 +43,8 @@ void test_fixedpoint_exp(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 6 + 2 * FixedType::M_2;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 2;
-    constexpr std::size_t SelectorColumns = 3;
+    constexpr std::size_t ConstantColumns = 5;
+    constexpr std::size_t SelectorColumns = 5;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -102,8 +102,8 @@ void test_fixedpoint_exp_ranged(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 16;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 2;
-    constexpr std::size_t SelectorColumns = 2;
+    constexpr std::size_t ConstantColumns = 5;
+    constexpr std::size_t SelectorColumns = 5;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -179,8 +179,8 @@ void test_fixedpoint_tanh(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 16;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 2;
-    constexpr std::size_t SelectorColumns = 4;
+    constexpr std::size_t ConstantColumns = 5;
+    constexpr std::size_t SelectorColumns = 10;
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;

--- a/test/algebra/fixedpoint/plonk/ml.cpp
+++ b/test/algebra/fixedpoint/plonk/ml.cpp
@@ -1,5 +1,8 @@
 #define BOOST_TEST_MODULE blueprint_plonk_fixedpoint_ml_test
 
+// Enable for faster tests
+// #define TEST_WITHOUT_LOOKUP_TABLES
+
 #include <boost/test/unit_test.hpp>
 
 #include <nil/crypto3/algebra/fields/bls12/scalar_field.hpp>
@@ -109,8 +112,8 @@ void test_fixedpoint_argmax_inner(FixedType x, FixedType y, typename FixedType::
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 10;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 1;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 3;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::plonk_arithmetization_params<WitnessColumns, PublicInputColumns,
                                                                                    ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -204,8 +207,8 @@ void test_fixedpoint_argmin_inner(FixedType x, FixedType y, typename FixedType::
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 10;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 1;
-    constexpr std::size_t SelectorColumns = 1;
+    constexpr std::size_t ConstantColumns = 3;
+    constexpr std::size_t SelectorColumns = 3;
     using ArithmetizationParams = crypto3::zk::snark::plonk_arithmetization_params<WitnessColumns, PublicInputColumns,
                                                                                    ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;

--- a/test/algebra/fixedpoint/plonk/tester.cpp
+++ b/test/algebra/fixedpoint/plonk/tester.cpp
@@ -178,7 +178,7 @@ template<typename FixedType, std::size_t RandomTestsAmount>
 void field_operations_test() {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 15;
-    constexpr std::size_t PublicInputColumns = blueprint::components::TESTER_MAX_PUBLIC_COLS;
+    constexpr std::size_t PublicInputColumns = 1;
     constexpr std::size_t ConstantColumns = blueprint::components::TESTER_MAX_CONSTANT_COLS;
     constexpr std::size_t SelectorColumns = 100;
     using ArithmetizationParams = crypto3::zk::snark::plonk_arithmetization_params<WitnessColumns, PublicInputColumns,
@@ -201,10 +201,7 @@ void field_operations_test() {
     for (auto i = 0; i < WitnessColumns; i++) {
         witness_list.push_back(i);
     }
-    std::array<std::uint32_t, PublicInputColumns> public_list;
-    for (auto i = 0; i < PublicInputColumns; i++) {
-        public_list[i] = i;
-    }
+    std::array<std::uint32_t, 0> public_list;
     std::array<std::uint32_t, ConstantColumns> constant_list;
     for (auto i = 0; i < ConstantColumns; i++) {
         constant_list[i] = i;
@@ -218,7 +215,9 @@ void field_operations_test() {
     std::vector<typename BlueprintFieldType::value_type> public_input = {};
 
     nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
-        component_instance, public_input, result_check, instance_input);
+        component_instance, public_input, result_check, instance_input,
+        crypto3::detail::connectedness_check_type::WEAK);
+    // We do not have inputs/outputs so the weak check is sufficient
 }
 
 constexpr static const std::size_t random_tests_amount = 10;

--- a/test/algebra/fixedpoint/plonk/tester.cpp
+++ b/test/algebra/fixedpoint/plonk/tester.cpp
@@ -510,6 +510,7 @@ template<typename FixedType, typename ComponentType>
 void test_components_unary_basic(ComponentType &component, int i) {
     FixedType x((int64_t)i);
 
+    // BASIC
     add_rescale<FixedType, ComponentType>(component, FixedType(x.get_value() * FixedType::DELTA, FixedType::SCALE * 2));
     add_neg<FixedType, ComponentType>(component, x);
     add_int_to_fixedpoint<FixedType, ComponentType>(component, (int64_t)i);

--- a/test/algebra/fixedpoint/plonk/tester.cpp
+++ b/test/algebra/fixedpoint/plonk/tester.cpp
@@ -36,6 +36,186 @@ bool doubleEquals(double a, double b, double epsilon) {
 }
 
 template<typename FixedType, typename ComponentType>
+void add_cmp(ComponentType &component, FixedType input1, FixedType input2) {
+    double input1_f = input1.to_double();
+    double input2_f = input2.to_double();
+    bool expected_res_less_f = input1_f < input2_f;
+    bool expected_res_greater_f = input1_f > input2_f;
+    bool expected_res_equal_f = fabs(input1_f - input2_f) < pow(2., -FixedType::SCALE);
+    bool expected_res_less = input1 < input2;
+    bool expected_res_greater = input1 > input2;
+    bool expected_res_equal = input1 == input2;
+
+    BLUEPRINT_RELEASE_ASSERT(expected_res_less_f == expected_res_less);
+    BLUEPRINT_RELEASE_ASSERT(expected_res_greater_f == expected_res_greater);
+    BLUEPRINT_RELEASE_ASSERT(expected_res_equal_f == expected_res_equal);
+    BLUEPRINT_RELEASE_ASSERT((uint8_t)expected_res_equal + (uint8_t)expected_res_greater + (uint8_t)expected_res_less ==
+                             1);
+
+    std::vector<typename FixedType::value_type> inputs = {input1.get_value(), input2.get_value()};
+    std::vector<typename FixedType::value_type> outputs = {expected_res_equal ? 1 : 0, expected_res_less ? 1 : 0,
+                                                           expected_res_greater ? 1 : 0};
+    std::vector<typename FixedType::value_type> constants = {};
+
+    component.add_testcase(blueprint::components::FixedPointComponents::CMP, inputs, outputs, constants);
+}
+
+template<typename FixedType, typename ComponentType>
+void add_cmp_extended(ComponentType &component, FixedType input1, FixedType input2) {
+    double input1_f = input1.to_double();
+    double input2_f = input2.to_double();
+    bool expected_res_less_f = input1_f < input2_f;
+    bool expected_res_greater_f = input1_f > input2_f;
+    bool expected_res_equal_f = fabs(input1_f - input2_f) < pow(2., -FixedType::SCALE);
+    bool expected_res_leq_f = input1_f <= input2_f;
+    bool expected_res_geq_f = input1_f >= input2_f;
+    bool expected_res_neq_f = fabs(input1_f - input2_f) >= pow(2., -FixedType::SCALE);
+    bool expected_res_less = input1 < input2;
+    bool expected_res_greater = input1 > input2;
+    bool expected_res_equal = input1 == input2;
+    bool expected_res_geq = input1 >= input2;
+    bool expected_res_leq = input1 <= input2;
+    bool expected_res_neq = input1 != input2;
+
+    BLUEPRINT_RELEASE_ASSERT(expected_res_less_f == expected_res_less);
+    BLUEPRINT_RELEASE_ASSERT(expected_res_greater_f == expected_res_greater);
+    BLUEPRINT_RELEASE_ASSERT(expected_res_equal_f == expected_res_equal);
+    BLUEPRINT_RELEASE_ASSERT(expected_res_leq_f == expected_res_leq);
+    BLUEPRINT_RELEASE_ASSERT(expected_res_geq_f == expected_res_geq);
+    BLUEPRINT_RELEASE_ASSERT(expected_res_neq_f == expected_res_neq);
+    BLUEPRINT_RELEASE_ASSERT((uint8_t)expected_res_equal + (uint8_t)expected_res_greater + (uint8_t)expected_res_less ==
+                             1);
+    BLUEPRINT_ASSERT(expected_res_eq != expected_res_neq);
+    BLUEPRINT_ASSERT(expected_res_geq != expected_res_less);
+    BLUEPRINT_ASSERT(expected_res_leq != expected_res_greater);
+
+    std::vector<typename FixedType::value_type> inputs = {input1.get_value(), input2.get_value()};
+    std::vector<typename FixedType::value_type> outputs = {expected_res_equal ? 1 : 0,   expected_res_less ? 1 : 0,
+                                                           expected_res_greater ? 1 : 0, expected_res_neq ? 1 : 0,
+                                                           expected_res_leq ? 1 : 0,     expected_res_geq ? 1 : 0};
+    std::vector<typename FixedType::value_type> constants = {};
+
+    component.add_testcase(blueprint::components::FixedPointComponents::CMP_EXTENDED, inputs, outputs, constants);
+}
+
+template<typename FixedType, typename ComponentType>
+void add_select_internal(ComponentType &component, FixedType input1, FixedType input2, bool input1_select) {
+
+    double expected_res_f = input1_select ? input1.to_double() : input2.to_double();
+    auto expected_res = input1_select ? input1 : input2;
+
+    BLUEPRINT_RELEASE_ASSERT(doubleEquals(expected_res_f, expected_res.to_double(), EPSILON));
+
+    std::vector<typename FixedType::value_type> inputs = {input1_select ? 1 : 0, input1.get_value(),
+                                                          input2.get_value()};
+    std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
+    std::vector<typename FixedType::value_type> constants = {};
+
+    component.add_testcase(blueprint::components::FixedPointComponents::SELECT, inputs, outputs, constants);
+}
+
+template<typename FixedType, typename ComponentType>
+void add_select(ComponentType &component, FixedType input1, FixedType input2) {
+    add_select_internal(component, input1, input2, true);
+    add_select_internal(component, input1, input2, false);
+}
+
+template<typename FixedType, typename ComponentType>
+void add_max(ComponentType &component, FixedType input1, FixedType input2) {
+    double input1_f = input1.to_double();
+    double input2_f = input2.to_double();
+    double expected_res_f = input1_f > input2_f ? input1_f : input2_f;
+    auto expected_res = input1 > input2 ? input1 : input2;
+
+    BLUEPRINT_RELEASE_ASSERT(doubleEquals(expected_res_f, expected_res.to_double(), EPSILON));
+
+    std::vector<typename FixedType::value_type> inputs = {input1.get_value(), input2.get_value()};
+    std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
+    std::vector<typename FixedType::value_type> constants = {};
+
+    component.add_testcase(blueprint::components::FixedPointComponents::MAX, inputs, outputs, constants);
+}
+
+template<typename FixedType, typename ComponentType>
+void add_min(ComponentType &component, FixedType input1, FixedType input2) {
+    double input1_f = input1.to_double();
+    double input2_f = input2.to_double();
+    double expected_res_f = input1_f < input2_f ? input1_f : input2_f;
+    auto expected_res = input1 < input2 ? input1 : input2;
+
+    BLUEPRINT_RELEASE_ASSERT(doubleEquals(expected_res_f, expected_res.to_double(), EPSILON));
+
+    std::vector<typename FixedType::value_type> inputs = {input1.get_value(), input2.get_value()};
+    std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
+    std::vector<typename FixedType::value_type> constants = {};
+
+    component.add_testcase(blueprint::components::FixedPointComponents::MIN, inputs, outputs, constants);
+}
+
+template<typename FixedType, typename ComponentType>
+void add_cmp_min_max(ComponentType &component, FixedType input1, FixedType input2) {
+    double input1_f = input1.to_double();
+    double input2_f = input2.to_double();
+    bool expected_res_less_f = input1_f < input2_f;
+    bool expected_res_greater_f = input1_f > input2_f;
+    bool expected_res_equal_f = fabs(input1_f - input2_f) < pow(2., -FixedType::SCALE);
+    double expected_res_min_f = input1_f < input2_f ? input1_f : input2_f;
+    double expected_res_max_f = input1_f > input2_f ? input1_f : input2_f;
+    bool expected_res_less = input1 < input2;
+    bool expected_res_greater = input1 > input2;
+    bool expected_res_equal = input1 == input2;
+    auto expected_res_min = input1 < input2 ? input1 : input2;
+    auto expected_res_max = input1 > input2 ? input1 : input2;
+
+    BLUEPRINT_RELEASE_ASSERT(expected_res_less_f == expected_res_less);
+    BLUEPRINT_RELEASE_ASSERT(expected_res_greater_f == expected_res_greater);
+    BLUEPRINT_RELEASE_ASSERT(expected_res_equal_f == expected_res_equal);
+    BLUEPRINT_RELEASE_ASSERT((uint8_t)expected_res_equal + (uint8_t)expected_res_greater + (uint8_t)expected_res_less ==
+                             1);
+
+    BLUEPRINT_RELEASE_ASSERT(doubleEquals(expected_res_min_f, expected_res_min.to_double(), EPSILON));
+    BLUEPRINT_RELEASE_ASSERT(doubleEquals(expected_res_max_f, expected_res_max.to_double(), EPSILON));
+
+    std::vector<typename FixedType::value_type> inputs = {input1.get_value(), input2.get_value()};
+    std::vector<typename FixedType::value_type> outputs = {expected_res_equal ? 1 : 0, expected_res_less ? 1 : 0,
+                                                           expected_res_greater ? 1 : 0, expected_res_min.get_value(),
+                                                           expected_res_max.get_value()};
+    std::vector<typename FixedType::value_type> constants = {};
+
+    component.add_testcase(blueprint::components::FixedPointComponents::CMP_MIN_MAX, inputs, outputs, constants);
+}
+
+template<typename FixedType, typename ComponentType>
+void add_range(ComponentType &component, FixedType input, FixedType x_lo, FixedType x_hi) {
+    if (x_lo > x_hi) {
+        std::swap(x_lo, x_hi);
+    }
+
+    double input_f = input.to_double();
+    double x_lo_f = x_lo.to_double();
+    double x_hi_f = x_hi.to_double();
+    bool expected_res_less_f = input_f < x_lo_f;
+    bool expected_res_greater_f = input_f > x_hi_f;
+    bool expected_res_in_f = (input_f >= x_lo_f) && (input_f <= x_hi_f);
+    bool expected_res_less = input < x_lo;
+    bool expected_res_greater = input > x_hi;
+    bool expected_res_in = (input >= x_lo) && (input <= x_hi);
+
+    BLUEPRINT_RELEASE_ASSERT(expected_res_less_f == expected_res_less);
+    BLUEPRINT_RELEASE_ASSERT(expected_res_greater_f == expected_res_greater);
+    BLUEPRINT_RELEASE_ASSERT(expected_res_in_f == expected_res_in);
+    BLUEPRINT_RELEASE_ASSERT((uint8_t)expected_res_in + (uint8_t)expected_res_greater + (uint8_t)expected_res_less ==
+                             1);
+
+    std::vector<typename FixedType::value_type> inputs = {input.get_value()};
+    std::vector<typename FixedType::value_type> outputs = {expected_res_in ? 1 : 0, expected_res_less ? 1 : 0,
+                                                           expected_res_greater ? 1 : 0};
+    std::vector<typename FixedType::value_type> constants = {x_lo.get_value(), x_hi.get_value()};
+
+    component.add_testcase(blueprint::components::FixedPointComponents::RANGE, inputs, outputs, constants);
+}
+
+template<typename FixedType, typename ComponentType>
 void add_gather_acc_inner(ComponentType &component, FixedType acc, FixedType data,
                           typename FixedType::value_type index_a, typename FixedType::value_type index_b) {
 
@@ -204,6 +384,15 @@ void test_components_binary_basic(ComponentType &component, int i, int j) {
     auto index_a = FixedType::value_type::one();
     auto index_b = typename FixedType::value_type(2);
 
+    // CMP
+    add_select<FixedType, ComponentType>(component, x, y);
+    add_cmp<FixedType, ComponentType>(component, x, y);
+    add_cmp_extended<FixedType, ComponentType>(component, x, y);
+    add_max<FixedType, ComponentType>(component, x, y);
+    add_min<FixedType, ComponentType>(component, x, y);
+    add_cmp_min_max<FixedType, ComponentType>(component, x, y);
+    add_range<FixedType, ComponentType>(component, x, x, y);
+
     // ML
     add_gather_acc<FixedType, ComponentType>(component, x, y, index_a, index_b);
     add_argmax<FixedType, ComponentType>(component, x, y, index_a, index_b);
@@ -216,12 +405,23 @@ void test_components_on_random_data(ComponentType &component, std::size_t i, Rng
                 FixedType::SCALE);
     FixedType y(generate_random_for_fixedpoint<typename FixedType::value_type>(FixedType::M_1, FixedType::M_2, rng),
                 FixedType::SCALE);
+    FixedType z(generate_random_for_fixedpoint<typename FixedType::value_type>(FixedType::M_1, FixedType::M_2, rng),
+                FixedType::SCALE);
 
     auto index_a = generate_random_index<typename FixedType::value_type>(rng);
     auto index_b = generate_random_index<typename FixedType::value_type>(rng);
     while (index_a == index_b) {
         index_b = generate_random_index<typename FixedType::value_type>(rng);
     }
+
+    // CMP
+    add_select<FixedType, ComponentType>(component, x, y);
+    add_cmp<FixedType, ComponentType>(component, x, y);
+    add_cmp_extended<FixedType, ComponentType>(component, x, y);
+    add_max<FixedType, ComponentType>(component, x, y);
+    add_min<FixedType, ComponentType>(component, x, y);
+    add_cmp_min_max<FixedType, ComponentType>(component, x, y);
+    add_range<FixedType, ComponentType>(component, x, y, z);
 
     // ML
     add_gather_acc<FixedType, ComponentType>(component, x, y, index_a, index_b);

--- a/test/algebra/fixedpoint/plonk/tester.cpp
+++ b/test/algebra/fixedpoint/plonk/tester.cpp
@@ -837,8 +837,8 @@ void test_components_unary_basic(ComponentType &component, int i) {
             auto q_dbl = static_cast<double>(quadrant);
             FixedType a(i_dbl * pi_two + pi_half * q_dbl);
             FixedType b(i_dbl * pi_two + pi_half * q_dbl + pi_half / 2.);
-            // add_sin<FixedType, ComponentType>(component, a);
-            // add_cos<FixedType, ComponentType>(component, b);
+            add_sin<FixedType, ComponentType>(component, a);
+            add_cos<FixedType, ComponentType>(component, b);
         }
     }
 }
@@ -982,8 +982,8 @@ void test_components_on_random_data(ComponentType &component, RngType &rng) {
     add_argmin<FixedType, ComponentType>(component, x, y, index_a, index_b);
 
     // TRIGON
-    // add_sin<FixedType, ComponentType>(component, x);
-    // add_cos<FixedType, ComponentType>(component, x);
+    add_sin<FixedType, ComponentType>(component, x);
+    add_cos<FixedType, ComponentType>(component, x);
 }
 
 template<typename FixedType, typename ComponentType, typename RngType>

--- a/test/algebra/fixedpoint/plonk/tester.cpp
+++ b/test/algebra/fixedpoint/plonk/tester.cpp
@@ -27,6 +27,7 @@ using namespace nil;
 using blueprint::components::FixedPoint;
 
 static constexpr double EPSILON = 0.001;
+static constexpr double EPSILON_SMALL = 0.01;
 
 bool doubleEquals(double a, double b, double epsilon) {
     // Essentially equal from
@@ -683,7 +684,7 @@ void add_sin(ComponentType &component, FixedType input) {
     double expected_res_f = sin(input.to_double());
     auto expected_res = input.sin();
 
-    BLUEPRINT_RELEASE_ASSERT(doubleEqualsExp(expected_res_f, expected_res.to_double(), EPSILON));
+    BLUEPRINT_RELEASE_ASSERT(doubleEqualsExp(expected_res_f, expected_res.to_double(), EPSILON_SMALL));
 
     std::vector<typename FixedType::value_type> inputs = {input.get_value()};
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
@@ -696,16 +697,16 @@ void add_sin(ComponentType &component, FixedType input) {
 template<typename FixedType, typename ComponentType>
 void add_cos(ComponentType &component, FixedType input) {
 
-    double expected_res_f = sin(input.to_double());
-    auto expected_res = input.sin();
+    double expected_res_f = cos(input.to_double());
+    auto expected_res = input.cos();
 
-    BLUEPRINT_RELEASE_ASSERT(doubleEqualsExp(expected_res_f, expected_res.to_double(), EPSILON));
+    BLUEPRINT_RELEASE_ASSERT(doubleEqualsExp(expected_res_f, expected_res.to_double(), EPSILON_SMALL));
 
     std::vector<typename FixedType::value_type> inputs = {input.get_value()};
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
     std::vector<typename FixedType::value_type> constants = {};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::SIN, inputs, outputs, constants, FixedType::M_1,
+    component.add_testcase(blueprint::components::FixedPointComponents::COS, inputs, outputs, constants, FixedType::M_1,
                            FixedType::M_2);
 }
 

--- a/test/algebra/fixedpoint/plonk/tester.cpp
+++ b/test/algebra/fixedpoint/plonk/tester.cpp
@@ -1,7 +1,7 @@
 #define BOOST_TEST_MODULE blueprint_plonk_fixedpoint_tester_test
 
 // Enable for faster tests
-#define TEST_WITHOUT_LOOKUP_TABLES
+// #define TEST_WITHOUT_LOOKUP_TABLES
 
 #include <boost/test/unit_test.hpp>
 
@@ -1080,8 +1080,8 @@ template<typename BlueprintFieldType, std::size_t RandomTestsAmount>
 void field_operations_test() {
     constexpr std::size_t WitnessColumns = 15;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = 15;
-    constexpr std::size_t SelectorColumns = 100;
+    constexpr std::size_t ConstantColumns = 50;
+    constexpr std::size_t SelectorColumns = 200;
     using ArithmetizationParams = crypto3::zk::snark::plonk_arithmetization_params<WitnessColumns, PublicInputColumns,
                                                                                    ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;

--- a/test/algebra/fixedpoint/plonk/tester.cpp
+++ b/test/algebra/fixedpoint/plonk/tester.cpp
@@ -36,6 +36,36 @@ bool doubleEquals(double a, double b, double epsilon) {
 }
 
 template<typename FixedType, typename ComponentType>
+void add_add(ComponentType &component, FixedType input1, FixedType input2) {
+
+    double expected_res_f = input1.to_double() + input2.to_double();
+    auto expected_res = input1 + input2;
+
+    BLUEPRINT_RELEASE_ASSERT(doubleEquals(expected_res_f, expected_res.to_double(), EPSILON));
+
+    std::vector<typename FixedType::value_type> inputs = {input1.get_value(), input2.get_value()};
+    std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
+    std::vector<typename FixedType::value_type> constants = {};
+
+    component.add_testcase(blueprint::components::FixedPointComponents::ADD, inputs, outputs, constants);
+}
+
+template<typename FixedType, typename ComponentType>
+void add_sub(ComponentType &component, FixedType input1, FixedType input2) {
+
+    double expected_res_f = input1.to_double() - input2.to_double();
+    auto expected_res = input1 - input2;
+
+    BLUEPRINT_RELEASE_ASSERT(doubleEquals(expected_res_f, expected_res.to_double(), EPSILON));
+
+    std::vector<typename FixedType::value_type> inputs = {input1.get_value(), input2.get_value()};
+    std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
+    std::vector<typename FixedType::value_type> constants = {};
+
+    component.add_testcase(blueprint::components::FixedPointComponents::SUB, inputs, outputs, constants);
+}
+
+template<typename FixedType, typename ComponentType>
 void add_cmp(ComponentType &component, FixedType input1, FixedType input2) {
     double input1_f = input1.to_double();
     double input2_f = input2.to_double();
@@ -384,6 +414,22 @@ void test_components_binary_basic(ComponentType &component, int i, int j) {
     auto index_a = FixedType::value_type::one();
     auto index_b = typename FixedType::value_type(2);
 
+    // BASIC
+    add_add<FixedType, ComponentType>(component, x, y);
+    add_sub<FixedType, ComponentType>(component, x, y);
+    // // test_fixedpoint_rescale<FixedType>(FixedType(x.get_value() * FixedType::DELTA, FixedType::SCALE * 2));
+    // add_mul_rescale<FixedType, ComponentType>(component, x, y);
+    // add_mul_rescale_const<FixedType, ComponentType>(component, x, y);
+    // // test_fixedpoint_neg<FixedType>(x);
+    // // test_int_to_fixedpoint<FixedType>((int64_t)i);
+    // if (y.get_value() != 0) {
+    //     add_div<FixedType, ComponentType>(component, x, y);
+    //     add_mod<FixedType, ComponentType>(component, x, y);
+    //     // if (y.geq_0()) {
+    //     // test_fixedpoint_div_by_pos<FixedType>(x, y);
+    //     // }
+    // }
+
     // CMP
     add_select<FixedType, ComponentType>(component, x, y);
     add_cmp<FixedType, ComponentType>(component, x, y);
@@ -413,6 +459,22 @@ void test_components_on_random_data(ComponentType &component, std::size_t i, Rng
     while (index_a == index_b) {
         index_b = generate_random_index<typename FixedType::value_type>(rng);
     }
+
+    // BASIC
+    add_add<FixedType, ComponentType>(component, x, y);
+    add_sub<FixedType, ComponentType>(component, x, y);
+    // // test_fixedpoint_rescale<FixedType>(FixedType(x.get_value() * FixedType::DELTA, FixedType::SCALE * 2));
+    // add_mul_rescale<FixedType, ComponentType>(component, x, y);
+    // add_mul_rescale_const<FixedType, ComponentType>(component, x, y);
+    // // test_fixedpoint_neg<FixedType>(x);
+    // // test_int_to_fixedpoint<FixedType>((int64_t)i);
+    // if (y.get_value() != 0) {
+    //     add_div<FixedType, ComponentType>(component, x, y);
+    //     add_mod<FixedType, ComponentType>(component, x, y);
+    //     // if (y.geq_0()) {
+    //     // test_fixedpoint_div_by_pos<FixedType>(x, y);
+    //     // }
+    // }
 
     // CMP
     add_select<FixedType, ComponentType>(component, x, y);

--- a/test/algebra/fixedpoint/plonk/tester.cpp
+++ b/test/algebra/fixedpoint/plonk/tester.cpp
@@ -677,6 +677,38 @@ void add_dot_2_gates(ComponentType &component, std::vector<FixedType> &input1, s
                            FixedType::M_1, FixedType::M_2, dots);
 }
 
+template<typename FixedType, typename ComponentType>
+void add_sin(ComponentType &component, FixedType input) {
+
+    double expected_res_f = sin(input.to_double());
+    auto expected_res = input.sin();
+
+    BLUEPRINT_RELEASE_ASSERT(doubleEqualsExp(expected_res_f, expected_res.to_double(), EPSILON));
+
+    std::vector<typename FixedType::value_type> inputs = {input.get_value()};
+    std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
+    std::vector<typename FixedType::value_type> constants = {};
+
+    component.add_testcase(blueprint::components::FixedPointComponents::SIN, inputs, outputs, constants, FixedType::M_1,
+                           FixedType::M_2);
+}
+
+template<typename FixedType, typename ComponentType>
+void add_cos(ComponentType &component, FixedType input) {
+
+    double expected_res_f = sin(input.to_double());
+    auto expected_res = input.sin();
+
+    BLUEPRINT_RELEASE_ASSERT(doubleEqualsExp(expected_res_f, expected_res.to_double(), EPSILON));
+
+    std::vector<typename FixedType::value_type> inputs = {input.get_value()};
+    std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
+    std::vector<typename FixedType::value_type> constants = {};
+
+    component.add_testcase(blueprint::components::FixedPointComponents::SIN, inputs, outputs, constants, FixedType::M_1,
+                           FixedType::M_2);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -783,6 +815,10 @@ template<typename FixedType, typename ComponentType>
 void test_components_unary_basic(ComponentType &component, int i) {
     FixedType x((int64_t)i);
 
+    constexpr double pi_half = 1.5707963267948966;
+    constexpr double pi = 3.141592653589793;
+    constexpr double pi_two = 6.283185307179586;
+
     // BASIC
     add_rescale<FixedType, ComponentType>(component, FixedType(x.get_value() * FixedType::DELTA, FixedType::SCALE * 2));
     add_neg<FixedType, ComponentType>(component, x);
@@ -792,6 +828,18 @@ void test_components_unary_basic(ComponentType &component, int i) {
     add_exp<FixedType, ComponentType>(component, x);
     add_exp_ranged<FixedType, ComponentType>(component, x);
     add_tanh<FixedType, ComponentType>(component, x);
+
+    // TRIGON
+    for (int i = -2; i < 3; i++) {
+        auto i_dbl = static_cast<double>(i);
+        for (int quadrant = 0; quadrant < 4; quadrant++) {
+            auto q_dbl = static_cast<double>(quadrant);
+            FixedType a(i_dbl * pi_two + pi_half * q_dbl);
+            FixedType b(i_dbl * pi_two + pi_half * q_dbl + pi_half / 2.);
+            add_sin<FixedType, ComponentType>(component, a);
+            add_cos<FixedType, ComponentType>(component, b);
+        }
+    }
 }
 
 template<typename FixedType, typename ComponentType>
@@ -931,6 +979,10 @@ void test_components_on_random_data(ComponentType &component, RngType &rng) {
     add_gather_acc<FixedType, ComponentType>(component, x, y, index_a, index_b);
     add_argmax<FixedType, ComponentType>(component, x, y, index_a, index_b);
     add_argmin<FixedType, ComponentType>(component, x, y, index_a, index_b);
+
+    // TRIGON
+    add_sin<FixedType, ComponentType>(component, x);
+    add_cos<FixedType, ComponentType>(component, x);
 }
 
 template<typename FixedType, typename ComponentType, typename RngType>

--- a/test/algebra/fixedpoint/plonk/tester.cpp
+++ b/test/algebra/fixedpoint/plonk/tester.cpp
@@ -1,7 +1,7 @@
 #define BOOST_TEST_MODULE blueprint_plonk_fixedpoint_tester_test
 
 // Enable for faster tests
-#define TEST_WITHOUT_LOOKUP_TABLES
+// #define TEST_WITHOUT_LOOKUP_TABLES
 
 #include <boost/test/unit_test.hpp>
 
@@ -179,7 +179,7 @@ void field_operations_test() {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 15;
     constexpr std::size_t PublicInputColumns = 1;
-    constexpr std::size_t ConstantColumns = blueprint::components::TESTER_MAX_CONSTANT_COLS;
+    constexpr std::size_t ConstantColumns = 15;
     constexpr std::size_t SelectorColumns = 100;
     using ArithmetizationParams = crypto3::zk::snark::plonk_arithmetization_params<WitnessColumns, PublicInputColumns,
                                                                                    ConstantColumns, SelectorColumns>;
@@ -202,8 +202,8 @@ void field_operations_test() {
         witness_list.push_back(i);
     }
     std::array<std::uint32_t, 0> public_list;
-    std::array<std::uint32_t, ConstantColumns> constant_list;
-    for (auto i = 0; i < ConstantColumns; i++) {
+    std::array<std::uint32_t, blueprint::components::TESTER_MAX_CONSTANT_COLS> constant_list;
+    for (auto i = 0; i < blueprint::components::TESTER_MAX_CONSTANT_COLS; i++) {
         constant_list[i] = i;
     }
 

--- a/test/algebra/fixedpoint/plonk/tester.cpp
+++ b/test/algebra/fixedpoint/plonk/tester.cpp
@@ -27,7 +27,6 @@ using namespace nil;
 using blueprint::components::FixedPoint;
 
 static constexpr double EPSILON = 0.001;
-static constexpr double EPSILON_SMALL = 0.01;
 
 bool doubleEquals(double a, double b, double epsilon) {
     // Essentially equal from
@@ -684,7 +683,7 @@ void add_sin(ComponentType &component, FixedType input) {
     double expected_res_f = sin(input.to_double());
     auto expected_res = input.sin();
 
-    BLUEPRINT_RELEASE_ASSERT(doubleEqualsExp(expected_res_f, expected_res.to_double(), EPSILON_SMALL));
+    BLUEPRINT_RELEASE_ASSERT(doubleEqualsExp(expected_res_f, expected_res.to_double(), EPSILON));
 
     std::vector<typename FixedType::value_type> inputs = {input.get_value()};
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
@@ -700,7 +699,7 @@ void add_cos(ComponentType &component, FixedType input) {
     double expected_res_f = cos(input.to_double());
     auto expected_res = input.cos();
 
-    BLUEPRINT_RELEASE_ASSERT(doubleEqualsExp(expected_res_f, expected_res.to_double(), EPSILON_SMALL));
+    BLUEPRINT_RELEASE_ASSERT(doubleEqualsExp(expected_res_f, expected_res.to_double(), EPSILON));
 
     std::vector<typename FixedType::value_type> inputs = {input.get_value()};
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};

--- a/test/algebra/fixedpoint/plonk/tester.cpp
+++ b/test/algebra/fixedpoint/plonk/tester.cpp
@@ -1132,7 +1132,7 @@ void field_operations_test_inner(ComponentType &component) {
     constexpr std::size_t WitnessColumns = 15;                                                                         \
     constexpr std::size_t PublicInputColumns = 1;                                                                      \
     constexpr std::size_t ConstantColumns = 30;                                                                        \
-    constexpr std::size_t SelectorColumns = 50;                                                                        \
+    constexpr std::size_t SelectorColumns = 70;                                                                        \
     using ArithmetizationParams = crypto3::zk::snark::plonk_arithmetization_params<WitnessColumns, PublicInputColumns, \
                                                                                    ConstantColumns, SelectorColumns>;  \
     using ArithmetizationType =                                                                                        \

--- a/test/algebra/fixedpoint/plonk/tester.cpp
+++ b/test/algebra/fixedpoint/plonk/tester.cpp
@@ -24,8 +24,7 @@
 #include "../../../test_plonk_component.hpp"
 
 using namespace nil;
-using nil::blueprint::components::FixedPoint16_16;
-using nil::blueprint::components::FixedPoint32_32;
+using blueprint::components::FixedPoint;
 
 static constexpr double EPSILON = 0.001;
 
@@ -47,7 +46,8 @@ void add_add(ComponentType &component, FixedType input1, FixedType input2) {
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
     std::vector<typename FixedType::value_type> constants = {};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::ADD, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::ADD, inputs, outputs, constants, FixedType::M_1,
+                           FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -62,7 +62,8 @@ void add_sub(ComponentType &component, FixedType input1, FixedType input2) {
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
     std::vector<typename FixedType::value_type> constants = {};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::SUB, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::SUB, inputs, outputs, constants, FixedType::M_1,
+                           FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -77,7 +78,8 @@ void add_mul_rescale(ComponentType &component, FixedType input1, FixedType input
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
     std::vector<typename FixedType::value_type> constants = {};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::MUL_RESCALE, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::MUL_RESCALE, inputs, outputs, constants,
+                           FixedType::M_1, FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -92,7 +94,8 @@ void add_mul_rescale_const(ComponentType &component, FixedType input1, FixedType
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
     std::vector<typename FixedType::value_type> constants = {input2.get_value()};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::MUL_RESCALE_CONST, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::MUL_RESCALE_CONST, inputs, outputs, constants,
+                           FixedType::M_1, FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -107,7 +110,8 @@ void add_div(ComponentType &component, FixedType input1, FixedType input2) {
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
     std::vector<typename FixedType::value_type> constants = {};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::DIV, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::DIV, inputs, outputs, constants, FixedType::M_1,
+                           FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -127,7 +131,8 @@ void add_mod(ComponentType &component, FixedType input1, FixedType input2) {
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
     std::vector<typename FixedType::value_type> constants = {};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::REM, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::REM, inputs, outputs, constants, FixedType::M_1,
+                           FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -142,7 +147,8 @@ void add_rescale(ComponentType &component, FixedType input) {
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
     std::vector<typename FixedType::value_type> constants = {};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::RESCALE, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::RESCALE, inputs, outputs, constants,
+                           FixedType::M_1, FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -157,7 +163,8 @@ void add_neg(ComponentType &component, FixedType input) {
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
     std::vector<typename FixedType::value_type> constants = {};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::NEG, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::NEG, inputs, outputs, constants, FixedType::M_1,
+                           FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -172,7 +179,8 @@ void add_int_to_fixedpoint(ComponentType &component, typename FixedType::value_t
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
     std::vector<typename FixedType::value_type> constants = {};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::TO_FIXEDPOINT, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::TO_FIXEDPOINT, inputs, outputs, constants,
+                           FixedType::M_1, FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -197,7 +205,8 @@ void add_cmp(ComponentType &component, FixedType input1, FixedType input2) {
                                                            expected_res_greater ? 1 : 0};
     std::vector<typename FixedType::value_type> constants = {};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::CMP, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::CMP, inputs, outputs, constants, FixedType::M_1,
+                           FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -235,7 +244,8 @@ void add_cmp_extended(ComponentType &component, FixedType input1, FixedType inpu
                                                            expected_res_leq ? 1 : 0,     expected_res_geq ? 1 : 0};
     std::vector<typename FixedType::value_type> constants = {};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::CMP_EXTENDED, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::CMP_EXTENDED, inputs, outputs, constants,
+                           FixedType::M_1, FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -251,7 +261,8 @@ void add_select_internal(ComponentType &component, FixedType input1, FixedType i
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
     std::vector<typename FixedType::value_type> constants = {};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::SELECT, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::SELECT, inputs, outputs, constants,
+                           FixedType::M_1, FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -273,7 +284,8 @@ void add_max(ComponentType &component, FixedType input1, FixedType input2) {
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
     std::vector<typename FixedType::value_type> constants = {};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::MAX, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::MAX, inputs, outputs, constants, FixedType::M_1,
+                           FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -289,7 +301,8 @@ void add_min(ComponentType &component, FixedType input1, FixedType input2) {
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
     std::vector<typename FixedType::value_type> constants = {};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::MIN, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::MIN, inputs, outputs, constants, FixedType::M_1,
+                           FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -322,7 +335,8 @@ void add_cmp_min_max(ComponentType &component, FixedType input1, FixedType input
                                                            expected_res_max.get_value()};
     std::vector<typename FixedType::value_type> constants = {};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::CMP_MIN_MAX, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::CMP_MIN_MAX, inputs, outputs, constants,
+                           FixedType::M_1, FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -352,7 +366,8 @@ void add_range(ComponentType &component, FixedType input, FixedType x_lo, FixedT
                                                            expected_res_greater ? 1 : 0};
     std::vector<typename FixedType::value_type> constants = {x_lo.get_value(), x_hi.get_value()};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::RANGE, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::RANGE, inputs, outputs, constants,
+                           FixedType::M_1, FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -368,7 +383,8 @@ void add_gather_acc_inner(ComponentType &component, FixedType acc, FixedType dat
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value()};
     std::vector<typename FixedType::value_type> constants = {index_b};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::GATHER_ACC, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::GATHER_ACC, inputs, outputs, constants,
+                           FixedType::M_1, FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -411,7 +427,8 @@ void add_argmax_inner(ComponentType &component, FixedType x, FixedType y, typena
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value(), expected_index};
     std::vector<typename FixedType::value_type> constants = {index_y, select_last_index ? 1 : 0};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::ARGMAX, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::ARGMAX, inputs, outputs, constants,
+                           FixedType::M_1, FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -456,7 +473,8 @@ void add_argmin_inner(ComponentType &component, FixedType x, FixedType y, typena
     std::vector<typename FixedType::value_type> outputs = {expected_res.get_value(), expected_index};
     std::vector<typename FixedType::value_type> constants = {index_y, select_last_index ? 1 : 0};
 
-    component.add_testcase(blueprint::components::FixedPointComponents::ARGMIN, inputs, outputs, constants);
+    component.add_testcase(blueprint::components::FixedPointComponents::ARGMIN, inputs, outputs, constants,
+                           FixedType::M_1, FixedType::M_2);
 }
 
 template<typename FixedType, typename ComponentType>
@@ -623,9 +641,8 @@ void field_operations_test_inner(ComponentType &component) {
     }
 }
 
-template<typename FixedType, std::size_t RandomTestsAmount>
+template<typename BlueprintFieldType, std::size_t RandomTestsAmount>
 void field_operations_test() {
-    using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = 15;
     constexpr std::size_t PublicInputColumns = 1;
     constexpr std::size_t ConstantColumns = 15;
@@ -656,9 +673,17 @@ void field_operations_test() {
         constant_list[i] = i;
     }
 
-    component_type component_instance(witness_list, constant_list, public_list, FixedType::M_1, FixedType::M_2);
+    component_type component_instance(witness_list, constant_list, public_list);
 
-    field_operations_test_inner<FixedType, component_type, RandomTestsAmount>(component_instance);
+    // Add tests for all FixedTypes
+    field_operations_test_inner<FixedPoint<BlueprintFieldType, 1, 1>, component_type, RandomTestsAmount>(
+        component_instance);
+    field_operations_test_inner<FixedPoint<BlueprintFieldType, 1, 2>, component_type, RandomTestsAmount>(
+        component_instance);
+    field_operations_test_inner<FixedPoint<BlueprintFieldType, 2, 1>, component_type, RandomTestsAmount>(
+        component_instance);
+    field_operations_test_inner<FixedPoint<BlueprintFieldType, 2, 2>, component_type, RandomTestsAmount>(
+        component_instance);
 
     typename component_type::input_type instance_input = {};
     std::vector<typename BlueprintFieldType::value_type> public_input = {};
@@ -675,20 +700,17 @@ BOOST_AUTO_TEST_SUITE(blueprint_plonk_test_suite)
 
 BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_tester_test_vesta) {
     using field_type = typename crypto3::algebra::curves::vesta::base_field_type;
-    field_operations_test<FixedPoint16_16<field_type>, random_tests_amount>();
-    field_operations_test<FixedPoint32_32<field_type>, random_tests_amount>();
+    field_operations_test<field_type, random_tests_amount>();
 }
 
 BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_tester_test_pallas) {
     using field_type = typename crypto3::algebra::curves::pallas::base_field_type;
-    field_operations_test<FixedPoint16_16<field_type>, random_tests_amount>();
-    field_operations_test<FixedPoint32_32<field_type>, random_tests_amount>();
+    field_operations_test<field_type, random_tests_amount>();
 }
 
 BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_tester_test_bls12) {
     using field_type = typename crypto3::algebra::fields::bls12_fr<381>;
-    field_operations_test<FixedPoint16_16<field_type>, random_tests_amount>();
-    field_operations_test<FixedPoint32_32<field_type>, random_tests_amount>();
+    field_operations_test<field_type, random_tests_amount>();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/algebra/fixedpoint/plonk/tester.cpp
+++ b/test/algebra/fixedpoint/plonk/tester.cpp
@@ -1,0 +1,246 @@
+#define BOOST_TEST_MODULE blueprint_plonk_fixedpoint_tester_test
+
+// Enable for faster tests
+#define TEST_WITHOUT_LOOKUP_TABLES
+
+#include <boost/test/unit_test.hpp>
+
+#include <nil/crypto3/algebra/fields/bls12/scalar_field.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/bls12.hpp>
+#include <nil/crypto3/algebra/curves/vesta.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/vesta.hpp>
+#include <nil/crypto3/algebra/curves/pallas.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/pallas.hpp>
+
+#include <nil/crypto3/hash/keccak.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <boost/random/mersenne_twister.hpp>
+
+#include <nil/blueprint/blueprint/plonk/assignment.hpp>
+#include <nil/blueprint/blueprint/plonk/circuit.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/type.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp>
+
+#include "../../../test_plonk_component.hpp"
+
+using namespace nil;
+using nil::blueprint::components::FixedPoint16_16;
+using nil::blueprint::components::FixedPoint32_32;
+
+static constexpr double EPSILON = 0.001;
+
+bool doubleEquals(double a, double b, double epsilon) {
+    // Essentially equal from
+    // https://stackoverflow.com/questions/17333/how-do-you-compare-float-and-double-while-accounting-for-precision-loss
+    return fabs(a - b) <= ((fabs(a) > fabs(b) ? fabs(b) : fabs(a)) * epsilon);
+}
+
+template<typename FixedType, typename ComponentType>
+void add_argmax_inner(ComponentType &component, FixedType x, FixedType y, typename FixedType::value_type index_x,
+                      typename FixedType::value_type index_y, bool select_last_index) {
+    BLUEPRINT_RELEASE_ASSERT(index_x < index_y);
+
+    double x_f = x.to_double();
+    double y_f = y.to_double();
+
+    double expected_res_f;
+    FixedType expected_res(0, FixedType::SCALE);
+    typename FixedType::value_type expected_index;
+
+    expected_res_f = y.to_double();
+
+    if (select_last_index) {
+        // We have to evaluate x > y
+        expected_res_f = x_f > y_f ? x_f : y_f;
+        expected_res = x > y ? x : y;
+        expected_index = x_f > y_f ? index_x : index_y;
+    } else {
+        // We have to evaluate x >= y
+        expected_res_f = x_f >= y_f ? x_f : y_f;
+        expected_res = x >= y ? x : y;
+        expected_index = x_f >= y_f ? index_x : index_y;
+    }
+
+    BLUEPRINT_RELEASE_ASSERT(doubleEquals(expected_res_f, expected_res.to_double(), EPSILON));
+
+    std::vector<typename FixedType::value_type> inputs = {x.get_value(), y.get_value(), index_x};
+    std::vector<typename FixedType::value_type> outputs = {expected_res.get_value(), expected_index};
+    std::vector<typename FixedType::value_type> constants = {index_y, select_last_index ? 1 : 0};
+
+    component.add_testcase(blueprint::components::FixedPointComponents::ARGMAX, inputs, outputs, constants);
+}
+
+template<typename FixedType, typename ComponentType>
+void add_argmax(ComponentType &component, FixedType x, FixedType y, typename FixedType::value_type index_x,
+                typename FixedType::value_type index_y) {
+    if (index_y < index_x) {
+        std::swap(index_x, index_y);
+    }
+    add_argmax_inner<FixedType, ComponentType>(component, x, y, index_x, index_y, true);
+    add_argmax_inner<FixedType, ComponentType>(component, x, y, index_x, index_y, false);
+}
+
+static constexpr std::size_t INDEX_MAX = 1000;
+
+template<typename FieldType, typename RngType>
+FieldType generate_random_index(RngType &rng) {
+    using distribution = boost::random::uniform_int_distribution<uint64_t>;
+
+    distribution dist = distribution(0, INDEX_MAX);
+    uint64_t x = dist(rng);
+    return FieldType(x);
+}
+
+template<typename FieldType, typename RngType>
+FieldType generate_random_for_fixedpoint(uint8_t m1, uint8_t m2, RngType &rng) {
+    using distribution = boost::random::uniform_int_distribution<uint64_t>;
+
+    BLUEPRINT_RELEASE_ASSERT(m1 > 0 && m1 < 3);
+    BLUEPRINT_RELEASE_ASSERT(m2 > 0 && m2 < 3);
+    auto m = m1 + m2;
+
+    uint64_t max = 0;
+    if (m == 4) {
+        max = -1;
+    } else {
+        max = (1ull << (16 * m)) - 1;
+    }
+
+    distribution dist = distribution(0, max);
+    uint64_t x = dist(rng);
+    distribution dist_bool = distribution(0, 1);
+    bool sign = dist_bool(rng) == 1;
+    if (sign) {
+        return -FieldType(x);
+    } else {
+        return FieldType(x);
+    }
+}
+
+template<typename FixedType, typename ComponentType>
+void test_components_unary_basic(ComponentType &component, int i) {
+    FixedType x((int64_t)i);
+}
+
+template<typename FixedType, typename ComponentType>
+void test_components_unary_positive(ComponentType &component, int i) {
+    FixedType x((int64_t)i);
+}
+
+template<typename FixedType, typename ComponentType>
+void test_components_binary_basic(ComponentType &component, int i, int j) {
+    FixedType x((int64_t)i);
+    FixedType y((int64_t)j);
+
+    auto index_a = FixedType::value_type::one();
+    auto index_b = typename FixedType::value_type(2);
+
+    add_argmax<FixedType, ComponentType>(component, x, y, index_a, index_b);
+}
+
+template<typename FixedType, typename ComponentType, typename RngType>
+void test_components_on_random_data(ComponentType &component, std::size_t i, RngType &rng) {
+    FixedType x(generate_random_for_fixedpoint<typename FixedType::value_type>(FixedType::M_1, FixedType::M_2, rng),
+                FixedType::SCALE);
+    FixedType y(generate_random_for_fixedpoint<typename FixedType::value_type>(FixedType::M_1, FixedType::M_2, rng),
+                FixedType::SCALE);
+
+    auto index_a = generate_random_index<typename FixedType::value_type>(rng);
+    auto index_b = generate_random_index<typename FixedType::value_type>(rng);
+    while (index_a == index_b) {
+        index_b = generate_random_index<typename FixedType::value_type>(rng);
+    }
+
+    add_argmax<FixedType, ComponentType>(component, x, y, index_a, index_b);
+}
+
+template<typename FixedType, typename ComponentType, std::size_t RandomTestsAmount>
+void field_operations_test_inner(ComponentType &component) {
+    for (int i = -2; i < 3; i++) {
+        // test_components_unary_basic<FixedType, ComponentType>(component, i);
+        for (int j = -2; j < 3; j++) {
+            test_components_binary_basic<FixedType, ComponentType>(component, i, j);
+        }
+    }
+
+    // for (int i = 0; i < 5; i++) {
+    //     test_components_unary_positive<FixedType, ComponentType>(component, i);
+    // }
+
+    boost::random::mt19937 seed_seq(0);
+    for (std::size_t i = 0; i < RandomTestsAmount; i++) {
+        //     test_components_on_bounded_random_data<FixedType, ComponentType>(component, seed_seq);
+        test_components_on_random_data<FixedType, ComponentType>(component, i, seed_seq);
+    }
+}
+
+template<typename FixedType, std::size_t RandomTestsAmount>
+void field_operations_test() {
+    using BlueprintFieldType = typename FixedType::field_type;
+    constexpr std::size_t WitnessColumns = 15;
+    constexpr std::size_t PublicInputColumns = blueprint::components::TESTER_MAX_PUBLIC_COLS;
+    constexpr std::size_t ConstantColumns = blueprint::components::TESTER_MAX_CONSTANT_COLS;
+    constexpr std::size_t SelectorColumns = 100;
+    using ArithmetizationParams = crypto3::zk::snark::plonk_arithmetization_params<WitnessColumns, PublicInputColumns,
+                                                                                   ConstantColumns, SelectorColumns>;
+    using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
+    using hash_type = nil::crypto3::hashes::keccak_1600<256>;
+    constexpr std::size_t Lambda = 40;
+    using AssignmentType = nil::blueprint::assignment<ArithmetizationType>;
+
+    using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
+
+    using component_type =
+        blueprint::components::fix_tester<ArithmetizationType, BlueprintFieldType,
+                                          nil::blueprint::basic_non_native_policy<BlueprintFieldType>>;
+
+    auto result_check = [](AssignmentType &assignment, typename component_type::result_type &real_res) {};
+
+    std::vector<std::uint32_t> witness_list;
+    witness_list.reserve(WitnessColumns);
+    for (auto i = 0; i < WitnessColumns; i++) {
+        witness_list.push_back(i);
+    }
+    std::array<std::uint32_t, PublicInputColumns> public_list;
+    for (auto i = 0; i < PublicInputColumns; i++) {
+        public_list[i] = i;
+    }
+    std::array<std::uint32_t, ConstantColumns> constant_list;
+    for (auto i = 0; i < ConstantColumns; i++) {
+        constant_list[i] = i;
+    }
+
+    component_type component_instance(witness_list, constant_list, public_list, FixedType::M_1, FixedType::M_2);
+
+    field_operations_test_inner<FixedType, component_type, RandomTestsAmount>(component_instance);
+
+    typename component_type::input_type instance_input = {};
+    std::vector<typename BlueprintFieldType::value_type> public_input = {};
+
+    nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
+        component_instance, public_input, result_check, instance_input);
+}
+
+constexpr static const std::size_t random_tests_amount = 10;
+
+BOOST_AUTO_TEST_SUITE(blueprint_plonk_test_suite)
+
+BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_tester_test_vesta) {
+    using field_type = typename crypto3::algebra::curves::vesta::base_field_type;
+    field_operations_test<FixedPoint16_16<field_type>, random_tests_amount>();
+    field_operations_test<FixedPoint32_32<field_type>, random_tests_amount>();
+}
+
+BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_tester_test_pallas) {
+    using field_type = typename crypto3::algebra::curves::pallas::base_field_type;
+    field_operations_test<FixedPoint16_16<field_type>, random_tests_amount>();
+    field_operations_test<FixedPoint32_32<field_type>, random_tests_amount>();
+}
+
+BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_tester_test_bls12) {
+    using field_type = typename crypto3::algebra::fields::bls12_fr<381>;
+    field_operations_test<FixedPoint16_16<field_type>, random_tests_amount>();
+    field_operations_test<FixedPoint32_32<field_type>, random_tests_amount>();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/algebra/fixedpoint/plonk/trigonometric.cpp
+++ b/test/algebra/fixedpoint/plonk/trigonometric.cpp
@@ -49,7 +49,7 @@ bool doubleEquals(double a, double b, double epsilon) {
 template<typename FixedType>
 void test_fixedpoint_sin(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
-    constexpr std::size_t WitnessColumns = FixedType::M_2 == 1 ? 10 : 15;
+    constexpr std::size_t WitnessColumns = FixedType::M_2 == 2 ? 15 : FixedType::M_1 == 2 ? 11 : 10;
     constexpr std::size_t PublicInputColumns = 1;
 #ifdef TEST_WITHOUT_LOOKUP_TABLES
     constexpr std::size_t ConstantColumns = 1;
@@ -110,7 +110,7 @@ void test_fixedpoint_sin(FixedType input) {
 template<typename FixedType>
 void test_fixedpoint_cos(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
-    constexpr std::size_t WitnessColumns = FixedType::M_2 == 1 ? 9 : 14;
+    constexpr std::size_t WitnessColumns = FixedType::M_2 == 2 ? 14 : FixedType::M_1 == 2 ? 11 : 9;
     constexpr std::size_t PublicInputColumns = 1;
 #ifdef TEST_WITHOUT_LOOKUP_TABLES
     constexpr std::size_t ConstantColumns = 1;

--- a/test/algebra/fixedpoint/plonk/trigonometric.cpp
+++ b/test/algebra/fixedpoint/plonk/trigonometric.cpp
@@ -1,7 +1,7 @@
 #define BOOST_TEST_MODULE blueprint_plonk_fixedpoint_trigonometric_operations_test
 
 // Enable for faster tests
-#define TEST_WITHOUT_LOOKUP_TABLES
+// #define TEST_WITHOUT_LOOKUP_TABLES
 
 #include <boost/test/unit_test.hpp>
 
@@ -31,7 +31,7 @@ using nil::blueprint::components::FixedPoint32_32;
 static constexpr double EPSILON = 0.01;
 
 #define PRINT_FIXED_POINT_TEST(what)                                            \
-    std::cout << "fixed_point " << what << " test:\n";                                     \
+    std::cout << "fixed_point " << what << " test:\n";                          \
     std::cout << "input           : " << input.get_value().data << "\n";        \
     std::cout << "input (float)   : " << input.to_double() << "\n";             \
     std::cout << "expected        : " << expected_res.get_value().data << "\n"; \
@@ -51,8 +51,13 @@ void test_fixedpoint_sin(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = FixedType::M_2 == 1 ? 10 : 15;
     constexpr std::size_t PublicInputColumns = 1;
+#ifdef TEST_WITHOUT_LOOKUP_TABLES
     constexpr std::size_t ConstantColumns = 1;
     constexpr std::size_t SelectorColumns = FixedType::M_1 == 1 ? 1 : 2;
+#else
+    constexpr std::size_t ConstantColumns = 15;
+    constexpr std::size_t SelectorColumns = 15;
+#endif
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -102,14 +107,18 @@ void test_fixedpoint_sin(FixedType input) {
         component_instance, public_input, result_check, instance_input);
 }
 
-
 template<typename FixedType>
 void test_fixedpoint_cos(FixedType input) {
     using BlueprintFieldType = typename FixedType::field_type;
     constexpr std::size_t WitnessColumns = FixedType::M_2 == 1 ? 9 : 14;
     constexpr std::size_t PublicInputColumns = 1;
+#ifdef TEST_WITHOUT_LOOKUP_TABLES
     constexpr std::size_t ConstantColumns = 1;
     constexpr std::size_t SelectorColumns = FixedType::M_1 == 1 ? 1 : 2;
+#else
+    constexpr std::size_t ConstantColumns = 15;
+    constexpr std::size_t SelectorColumns = 15;
+#endif
     using ArithmetizationParams = crypto3::zk::snark::
         plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
     using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;

--- a/test/algebra/fixedpoint/plonk/trigonometric.cpp
+++ b/test/algebra/fixedpoint/plonk/trigonometric.cpp
@@ -1,0 +1,246 @@
+#define BOOST_TEST_MODULE blueprint_plonk_fixedpoint_trigonometric_operations_test
+
+// Enable for faster tests
+#define TEST_WITHOUT_LOOKUP_TABLES
+
+#include <boost/test/unit_test.hpp>
+
+#include <nil/crypto3/algebra/fields/bls12/scalar_field.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/bls12.hpp>
+#include <nil/crypto3/algebra/curves/vesta.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/vesta.hpp>
+#include <nil/crypto3/algebra/curves/pallas.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/pallas.hpp>
+
+#include <nil/crypto3/hash/keccak.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <boost/random/mersenne_twister.hpp>
+
+#include <nil/blueprint/blueprint/plonk/assignment.hpp>
+#include <nil/blueprint/blueprint/plonk/circuit.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/type.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/plonk/sin.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/plonk/cos.hpp>
+
+#include "../../../test_plonk_component.hpp"
+
+using namespace nil;
+using nil::blueprint::components::FixedPoint16_16;
+using nil::blueprint::components::FixedPoint32_32;
+
+static constexpr double EPSILON = 0.01;
+
+#define PRINT_FIXED_POINT_TEST(what)                                            \
+    std::cout << "fixed_point " << what << " test:\n";                                     \
+    std::cout << "input           : " << input.get_value().data << "\n";        \
+    std::cout << "input (float)   : " << input.to_double() << "\n";             \
+    std::cout << "expected        : " << expected_res.get_value().data << "\n"; \
+    std::cout << "real            : " << real_res_.get_value().data << "\n";    \
+    std::cout << "expected (float): " << expected_res_f << "\n";                \
+    std::cout << "real (float)    : " << real_res_f << "\n\n";
+
+bool doubleEquals(double a, double b, double epsilon) {
+    // Essentially equal from
+    // https://stackoverflow.com/questions/17333/how-do-you-compare-float-and-double-while-accounting-for-precision-loss
+    // or just smaller epsilon
+    return fabs(a - b) < epsilon || fabs(a - b) <= ((fabs(a) > fabs(b) ? fabs(b) : fabs(a)) * epsilon);
+}
+
+template<typename FixedType>
+void test_fixedpoint_sin(FixedType input) {
+    using BlueprintFieldType = typename FixedType::field_type;
+    constexpr std::size_t WitnessColumns = FixedType::M_2 == 1 ? 10 : 15;
+    constexpr std::size_t PublicInputColumns = 1;
+    constexpr std::size_t ConstantColumns = 1;
+    constexpr std::size_t SelectorColumns = FixedType::M_1 == 1 ? 1 : 2;
+    using ArithmetizationParams = crypto3::zk::snark::
+        plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
+    using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
+    using hash_type = nil::crypto3::hashes::keccak_1600<256>;
+    constexpr std::size_t Lambda = 40;
+    using AssignmentType = nil::blueprint::assignment<ArithmetizationType>;
+
+    using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
+
+    using component_type = blueprint::components::
+        fix_sin<ArithmetizationType, BlueprintFieldType, nil::blueprint::basic_non_native_policy<BlueprintFieldType>>;
+
+    typename component_type::input_type instance_input = {var(0, 0, false, var::column_type::public_input)};
+
+    double expected_res_f = sin(input.to_double());
+    auto expected_res = input.sin();
+
+    auto result_check = [&expected_res, &expected_res_f, input](AssignmentType &assignment,
+                                                                typename component_type::result_type &real_res) {
+        auto real_res_ = FixedType(var_value(assignment, real_res.output), FixedType::SCALE);
+        double real_res_f = real_res_.to_double();
+#ifdef BLUEPRINT_PLONK_PROFILING_ENABLED
+        PRINT_FIXED_POINT_TEST("sin")
+#endif
+        if (!doubleEquals(expected_res_f, real_res_f, EPSILON) || expected_res != real_res_) {
+            PRINT_FIXED_POINT_TEST("sin")
+            abort();
+        }
+    };
+
+    std::vector<std::uint32_t> witness_list;
+    witness_list.reserve(WitnessColumns);
+    for (auto i = 0; i < WitnessColumns; i++) {
+        witness_list.push_back(i);
+    }
+    std::vector<std::uint32_t> const_list;
+    const_list.reserve(ConstantColumns);
+    for (auto i = 0; i < ConstantColumns; i++) {
+        const_list.push_back(i);
+    }
+    // Is done by the manifest in a real circuit
+    component_type component_instance(
+        witness_list, const_list, std::array<std::uint32_t, 0>(), FixedType::M_1, FixedType::M_2);
+
+    std::vector<typename BlueprintFieldType::value_type> public_input = {input.get_value()};
+    nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
+        component_instance, public_input, result_check, instance_input);
+}
+
+
+template<typename FixedType>
+void test_fixedpoint_cos(FixedType input) {
+    using BlueprintFieldType = typename FixedType::field_type;
+    constexpr std::size_t WitnessColumns = FixedType::M_2 == 1 ? 9 : 14;
+    constexpr std::size_t PublicInputColumns = 1;
+    constexpr std::size_t ConstantColumns = 1;
+    constexpr std::size_t SelectorColumns = FixedType::M_1 == 1 ? 1 : 2;
+    using ArithmetizationParams = crypto3::zk::snark::
+        plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
+    using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
+    using hash_type = nil::crypto3::hashes::keccak_1600<256>;
+    constexpr std::size_t Lambda = 40;
+    using AssignmentType = nil::blueprint::assignment<ArithmetizationType>;
+
+    using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
+
+    using component_type = blueprint::components::
+        fix_cos<ArithmetizationType, BlueprintFieldType, nil::blueprint::basic_non_native_policy<BlueprintFieldType>>;
+
+    typename component_type::input_type instance_input = {var(0, 0, false, var::column_type::public_input)};
+
+    double expected_res_f = cos(input.to_double());
+    auto expected_res = input.cos();
+
+    auto result_check = [&expected_res, &expected_res_f, input](AssignmentType &assignment,
+                                                                typename component_type::result_type &real_res) {
+        auto real_res_ = FixedType(var_value(assignment, real_res.output), FixedType::SCALE);
+        double real_res_f = real_res_.to_double();
+#ifdef BLUEPRINT_PLONK_PROFILING_ENABLED
+        PRINT_FIXED_POINT_TEST("cos")
+#endif
+        if (!doubleEquals(expected_res_f, real_res_f, EPSILON) || expected_res != real_res_) {
+            PRINT_FIXED_POINT_TEST("cos")
+            abort();
+        }
+    };
+
+    std::vector<std::uint32_t> witness_list;
+    witness_list.reserve(WitnessColumns);
+    for (auto i = 0; i < WitnessColumns; i++) {
+        witness_list.push_back(i);
+    }
+    std::vector<std::uint32_t> const_list;
+    const_list.reserve(ConstantColumns);
+    for (auto i = 0; i < ConstantColumns; i++) {
+        const_list.push_back(i);
+    }
+    // Is done by the manifest in a real circuit
+    component_type component_instance(
+        witness_list, const_list, std::array<std::uint32_t, 0>(), FixedType::M_1, FixedType::M_2);
+
+    std::vector<typename BlueprintFieldType::value_type> public_input = {input.get_value()};
+    nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
+        component_instance, public_input, result_check, instance_input);
+}
+
+template<typename FieldType, typename RngType>
+FieldType generate_random_for_fixedpoint(uint8_t m1, uint8_t m2, RngType &rng) {
+    using distribution = boost::random::uniform_int_distribution<uint64_t>;
+
+    BLUEPRINT_RELEASE_ASSERT(m1 > 0 && m1 < 3);
+    BLUEPRINT_RELEASE_ASSERT(m2 > 0 && m2 < 3);
+    auto m = m1 + m2;
+
+    uint64_t max = 0;
+    if (m == 4) {
+        max = -1;
+    } else {
+        max = (1ull << (16 * m)) - 1;
+    }
+
+    distribution dist = distribution(0, max);
+    uint64_t x = dist(rng);
+    distribution dist_bool = distribution(0, 1);
+    bool sign = dist_bool(rng) == 1;
+    if (sign) {
+        return -FieldType(x);
+    } else {
+        return FieldType(x);
+    }
+}
+
+template<typename FixedType, typename RngType>
+void test_components_on_random_data(RngType &rng) {
+    FixedType x(generate_random_for_fixedpoint<typename FixedType::value_type>(FixedType::M_1, FixedType::M_2, rng),
+                FixedType::SCALE);
+    test_fixedpoint_sin<FixedType>(x);
+    test_fixedpoint_cos<FixedType>(x);
+}
+
+template<typename FixedType>
+void test_components(double i) {
+    FixedType x(i);
+    test_fixedpoint_sin<FixedType>(x);
+    test_fixedpoint_cos<FixedType>(x);
+}
+
+template<typename FixedType, std::size_t RandomTestsAmount>
+void field_operations_test() {
+    constexpr double pi_half = 1.5707963267948966;
+    constexpr double pi = 3.141592653589793;
+    constexpr double pi_two = 6.283185307179586;
+
+    for (int i = -2; i < 3; i++) {
+        auto i_dbl = static_cast<double>(i);
+        for (int quadrant = 0; quadrant < 4; quadrant++) {
+            auto q_dbl = static_cast<double>(quadrant);
+            test_components<FixedType>(i_dbl * pi_two + pi_half * q_dbl);
+            test_components<FixedType>(i_dbl * pi_two + pi_half * q_dbl + pi_half / 2.);
+        }
+    }
+
+    boost::random::mt19937 seed_seq(0);
+    for (std::size_t i = 0; i < RandomTestsAmount; i++) {
+        test_components_on_random_data<FixedType>(seed_seq);
+    }
+}
+
+constexpr static const std::size_t random_tests_amount = 10;
+
+BOOST_AUTO_TEST_SUITE(blueprint_plonk_test_suite)
+
+BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_trigonometric_test_vesta) {
+    using field_type = typename crypto3::algebra::curves::vesta::base_field_type;
+    field_operations_test<FixedPoint16_16<field_type>, random_tests_amount>();
+    field_operations_test<FixedPoint32_32<field_type>, random_tests_amount>();
+}
+
+BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_trigonometric_test_pallas) {
+    using field_type = typename crypto3::algebra::curves::pallas::base_field_type;
+    field_operations_test<FixedPoint16_16<field_type>, random_tests_amount>();
+    field_operations_test<FixedPoint32_32<field_type>, random_tests_amount>();
+}
+
+BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_trigonometric_test_bls12) {
+    using field_type = typename crypto3::algebra::fields::bls12_fr<381>;
+    field_operations_test<FixedPoint16_16<field_type>, random_tests_amount>();
+    field_operations_test<FixedPoint32_32<field_type>, random_tests_amount>();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_plonk_component.hpp
+++ b/test/test_plonk_component.hpp
@@ -286,8 +286,13 @@ namespace nil {
                 // So we reserve the first column for non-lookup constants. 
                 // Rather universal for testing
                 // We may start from zero if component doesn't use ordinary constants.
+                auto start_index = 1;
+                if constexpr (!blueprint::components::is_component_stretcher<
+                              BlueprintFieldType, ArithmetizationParams, ComponentType>::value) {
+                    start_index = component_type::constants_amount;
+                }
                 std::vector<size_t> lookup_columns_indices;
-                for( std::size_t i = 1; i < ArithmetizationParams::constant_columns; i++ )  lookup_columns_indices.push_back(i);
+                for( std::size_t i = start_index; i < ArithmetizationParams::constant_columns; i++ )  lookup_columns_indices.push_back(i);
                 desc.usable_rows_amount = zk::snark::detail::pack_lookup_tables(
                     bp.get_reserved_indices(),
                     bp.get_reserved_tables(),

--- a/test/test_plonk_component.hpp
+++ b/test/test_plonk_component.hpp
@@ -51,6 +51,7 @@
 //#include <nil/blueprint/utils/table_profiling.hpp>
 #include <nil/blueprint/utils/satisfiability_check.hpp>
 #include <nil/blueprint/component_stretcher.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/lookup_tables/tester.hpp>
 #include <nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp>
 #include <nil/blueprint/utils/connectedness_check.hpp>
 
@@ -286,6 +287,7 @@ namespace nil {
             }
 
             if(nil::blueprint::use_lookups<component_type>()){
+                BLUEPRINT_RELEASE_ASSERT(nil::blueprint::check_lookup_tables(bp, assignment));
                 // Components with lookups may use constant columns.
                 // But now all constants are placed in the first column.
                 // So we reserve the first column for non-lookup constants. 

--- a/test/test_plonk_component.hpp
+++ b/test/test_plonk_component.hpp
@@ -262,7 +262,7 @@ namespace nil {
             desc.usable_rows_amount = assignment.rows_amount();
 
             if (start_row + component_instance.rows_amount >= public_input.size()) {
-                BLUEPRINT_RELEASE_ASSERT(assignment.rows_amount() - start_row == component_instance.rows_amount &&
+                BLUEPRINT_RELEASE_ASSERT((assignment.rows_amount() - start_row == component_instance.rows_amount) &&
                                 "Component rows amount does not match actual rows amount.");
                 // Stretched components do not have a manifest, as they are dynamically generated.
                 if constexpr (!blueprint::components::is_component_stretcher<

--- a/test/test_plonk_component.hpp
+++ b/test/test_plonk_component.hpp
@@ -254,7 +254,7 @@ namespace nil {
                 // blueprint::detail::export_connectedness_zones(
                 //      zones, assignment, instance_input.all_vars(), start_row, component_instance.rows_amount, std::cout);
 
-                BOOST_ASSERT_MSG(is_connected,
+                BLUEPRINT_RELEASE_ASSERT(is_connected &&
                     "Component disconnected! See comment above this assert for a way to output a visual representation of the connectedness graph.");
             }
 
@@ -262,7 +262,7 @@ namespace nil {
             desc.usable_rows_amount = assignment.rows_amount();
 
             if (start_row + component_instance.rows_amount >= public_input.size()) {
-                BOOST_ASSERT_MSG(assignment.rows_amount() - start_row == component_instance.rows_amount,
+                BLUEPRINT_RELEASE_ASSERT(assignment.rows_amount() - start_row == component_instance.rows_amount &&
                                 "Component rows amount does not match actual rows amount.");
                 // Stretched components do not have a manifest, as they are dynamically generated.
                 if constexpr (!blueprint::components::is_component_stretcher<
@@ -316,7 +316,7 @@ namespace nil {
             profiling(assignment);
 #endif
 
-            assert(blueprint::is_satisfied(bp, assignment) == expected_to_pass);
+            BLUEPRINT_RELEASE_ASSERT(blueprint::is_satisfied(bp, assignment) == expected_to_pass);
 
             return std::make_tuple(desc, bp, assignment);
         }

--- a/test/test_plonk_component.hpp
+++ b/test/test_plonk_component.hpp
@@ -51,6 +51,7 @@
 //#include <nil/blueprint/utils/table_profiling.hpp>
 #include <nil/blueprint/utils/satisfiability_check.hpp>
 #include <nil/blueprint/component_stretcher.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/plonk/tester.hpp>
 #include <nil/blueprint/utils/connectedness_check.hpp>
 
 #include <nil/crypto3/math/algorithms/calculate_domain_set.hpp>
@@ -264,6 +265,8 @@ namespace nil {
                                 "Component rows amount does not match actual rows amount.");
                 // Stretched components do not have a manifest, as they are dynamically generated.
                 if constexpr (!blueprint::components::is_component_stretcher<
+                                    BlueprintFieldType, ArithmetizationParams, ComponentType>::value
+                           && !blueprint::components::is_component_tester<
                                     BlueprintFieldType, ArithmetizationParams, ComponentType>::value) {
                     BOOST_ASSERT_MSG(assignment.rows_amount() - start_row ==
                                     component_type::get_rows_amount(component_instance.witness_amount(), 0,
@@ -273,6 +276,8 @@ namespace nil {
             }
             // Stretched components do not have a manifest, as they are dynamically generated.
             if constexpr (!blueprint::components::is_component_stretcher<
+                                    BlueprintFieldType, ArithmetizationParams, ComponentType>::value
+                       && !blueprint::components::is_component_tester<
                                     BlueprintFieldType, ArithmetizationParams, ComponentType>::value) {
                 BOOST_ASSERT_MSG(bp.num_gates() + bp.num_lookup_gates()==
                                 component_type::get_gate_manifest(component_instance.witness_amount(), 0,


### PR DESCRIPTION
Implemented the following fixedpoint gadgets:
- Sin
- Cos

Other:
- Added lookup tables to all existing fixedpoint gadgets
- Added a tester component which allows to put testcases of other components into one trace
- Added a tester checking for correct lookup constraints in the trace