### PR TITLE
feat: Add gadgets for bitwise operations AND, OR, XOR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ list(APPEND ${CURRENT_PROJECT_NAME}_PUBLIC_HEADERS
     include/nil/crypto3/zk/components/boolean/r1cs/inner_product.hpp
     include/nil/crypto3/zk/components/detail/r1cs/loose_multiplexing.hpp
     include/nil/crypto3/zk/components/component_from_r1cs.hpp
+    include/nil/crypto3/zk/components/cell_position.hpp
     include/nil/crypto3/zk/component.hpp
     include/nil/crypto3/zk/blueprint/r1cs.hpp
     include/nil/crypto3/zk/blueprint/plonk.hpp)

--- a/include/nil/blueprint/components/algebra/fields/plonk/bitwise_and.hpp
+++ b/include/nil/blueprint/components/algebra/fields/plonk/bitwise_and.hpp
@@ -1,0 +1,512 @@
+#ifndef CRYPTO3_BLUEPRINT_COMPONENTS_PLONK_FIELD_BITWISE_AND_HPP
+#define CRYPTO3_BLUEPRINT_COMPONENTS_PLONK_FIELD_BITWISE_AND_HPP
+
+#include <nil/crypto3/zk/snark/arithmetization/plonk/constraint_system.hpp>
+
+#include <nil/blueprint/blueprint/plonk/assignment.hpp>
+#include <nil/blueprint/blueprint/plonk/circuit.hpp>
+#include <nil/blueprint/component.hpp>
+#include <nil/blueprint/manifest.hpp>
+#include <nil/blueprint/basic_non_native_policy.hpp>
+
+#include "nil/blueprint/components/cell_position.hpp"
+#include "nil/blueprint/components/algebra/fields/plonk/non_native/detail/bitwise_helper.hpp"
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+
+            // works via decomposing x and y into 8-bit limbs and one additional sign bit, and looking up the result of
+            // the bitwise operation for each 8-bit limb triples in a lookup table. The result is then reassembled from
+            // the lookup table result limbs.
+
+            /**
+             * Component representing a bitwise AND operation.
+             *
+             * Field elements greater than prime half are interpreted as negative numbers, similar to the repesentation
+             * of signed integers many in programming languages. The value of a field element gets deomposed into a
+             * dedicated sign bit and m 8-bit limbs and the bitwise operation gets applied to each pair of bits.
+             *
+             * Input:    x ... field element
+             *           y ... field element
+             * Output:   z ... x & y (field element)
+             * Constant: m ... number of 8-bit limbs (uint8_t), m in [1,8]
+             *           n ... negative part constant (field element), n = prime - 2^8m
+             */
+            template<typename ArithmetizationType, typename FieldType, typename NonNativePolicyType>
+            class bitwise_and;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams, typename NonNativePolicyType>
+            class bitwise_and<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                              BlueprintFieldType, NonNativePolicyType>
+                : public plonk_component<BlueprintFieldType, ArithmetizationParams, 1, 0> {
+
+            public:
+                using value_type = typename BlueprintFieldType::value_type;
+
+            private:
+                const uint8_t m;       // number of 8-bit limbs
+                const value_type n;    // negative part constant (field element): n = prime - 2^8m
+
+                static uint8_t M(uint8_t m) {
+                    if (m == 0 || m > 8) {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+                    return m;
+                }
+
+            public:
+                struct var_positions {
+                    CellPosition x, y, z, s_x, s_y, x0, x1, y0, y1, z0, z1, n;
+                    int64_t start_row;
+                };
+
+                var_positions get_var_pos(const int64_t start_row_index) const {
+
+                    auto m = this->m;
+                    var_positions pos;
+                    pos.start_row = start_row_index;
+                    pos.x = CellPosition(this->W(0), pos.start_row);
+                    pos.y = CellPosition(this->W(1), pos.start_row);
+                    pos.z = CellPosition(this->W(2), pos.start_row);
+                    pos.s_x = CellPosition(this->W(3), pos.start_row);
+                    pos.s_y = CellPosition(this->W(4), pos.start_row);
+                    pos.x0 = CellPosition(this->W(5 + (0 * m)), pos.start_row);    // occupies m cells
+                    pos.x1 = CellPosition(this->W(5 + (0 * m) + 1), pos.start_row);
+                    pos.n = CellPosition(this->C(0), pos.start_row);
+
+                    // trace layout constant (1 col(s), 1 row(s))
+                    //
+                    //     | constant |
+                    //  r\c|    0     |
+                    // +---+----------+
+                    // | 0 |    n     |
+
+                    if (rows_amount == 1) {
+                        // trace layout witness (1 col(s), 5 + 3m row(s))
+                        //
+                        //     |                                    witness                                     |
+                        //  r\c| 0 | 1 | 2 |  3  |  4  |  5  | .. | 5+m-1 | 5+m | .. | 5+2m-1| 5+2m| .. | 5+3m-1|
+                        // +---+---+---+---+-----+-----+-----+----+-------+-----+----+-------+-----+----+-------+
+                        // | 0 | x | y | z | s_x | s_y | x_0 | .. | x_m-1 | y_0 | .. | y_m-1 | z_0 | .. | z_m-1 |
+                        pos.y0 = CellPosition(this->W(5 + (1 * m)), pos.start_row);    // occupies m cells
+                        pos.y1 = CellPosition(this->W(5 + (1 * m) + 1), pos.start_row);
+                        pos.z0 = CellPosition(this->W(5 + (2 * m)), pos.start_row);    // occupies m cells
+                        pos.z1 = CellPosition(this->W(5 + (2 * m) + 1), pos.start_row);
+                    } else if (rows_amount == 2 && m < 8) {
+                        // trace layout witness (2 col(s), r row(s))
+                        // where r = max (m + 5, 2m)
+                        //
+                        //     |                 witness                  |
+                        //  r\c| 0 | 1 | 2 |  3  |  4  |  5  | .. | 5+m-1 |
+                        // +---+---+---+---+-----+-----+-----+----+-------+
+                        // | 0 | x | y | z | s_x | s_y | x_0 | .. | x_m-1 |
+
+                        //     |               witness               |
+                        //  r\c|  0  | .. |  m-1  |  m  | .. | 2m-1  |
+                        // +---+-----+----+-------+-----+----+-------+
+                        // | 1 | y_0 | .. | y_m-1 | z_0 | .. | z_m-1 |
+                        pos.y0 = CellPosition(this->W((0 * m)), pos.start_row + 1);    // occupies m cells
+                        pos.y1 = CellPosition(this->W((0 * m) + 1), pos.start_row + 1);
+                        pos.z0 = CellPosition(this->W((1 * m)), pos.start_row + 1);    // occupies m cells
+                        pos.z1 = CellPosition(this->W((1 * m) + 1), pos.start_row + 1);
+                    } else if (rows_amount == 2 && m == 8) {
+                        // trace layout witness (2 col(s), 15 row(s))
+                        //
+                        //     |                     witness                      |
+                        //  r\c| 0 | 1 | 2 |  3  |  4  |  5  | .. | 5+m-1 | 5 + m |
+                        // +---+---+---+---+-----+-----+-----+----+-------+-------+
+                        // | 0 | x | y | z | s_x | s_y | x_0 | .. | x_m-1 |  y_0  |
+
+                        //     |               witness               |
+                        //  r\c|  0  | .. |  m-2  | m-1 | .. | 2m-2  |
+                        // +---+-----+----+-------+-----+----+-------+
+                        // | 1 | y_1 | .. | y_m-1 | z_0 | .. | z_m-1 |
+                        pos.y0 = CellPosition(this->W(5 + m), pos.start_row);          // occupies 1 cell
+                        pos.y1 = CellPosition(this->W((0 * m)), pos.start_row + 1);    // occupies m-1 cells
+                        pos.z0 = CellPosition(this->W(m - 1), pos.start_row + 1);      // occupies m cells
+                        pos.z1 = CellPosition(this->W(m), pos.start_row + 1);
+                    } else {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+
+                    return pos;
+                }
+
+            public:
+                uint8_t get_m() const {
+                    return this->m;
+                }
+
+                static std::size_t get_witness_columns(uint8_t m) {
+                    if (3 * M(m) + 5 < 15) {
+                        return 3 * m + 5;
+                    } else if (m >= 4 && m < 8) {
+                        return std::max(m + 5, 2 * m);
+                    } else if (m == 8) {
+                        return 15;
+                    }
+                    BLUEPRINT_RELEASE_ASSERT(false);
+                    return 0;
+                }
+
+                using component_type = plonk_component<BlueprintFieldType, ArithmetizationParams, 1, 0>;
+
+                using var = typename component_type::var;
+                using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::lookup_table_definition<BlueprintFieldType>;
+                using bitwise_table = bitwise_table<BlueprintFieldType>;
+
+                class gate_manifest_type : public component_gate_manifest {
+                public:
+                    std::uint32_t gates_amount() const override {
+                        return bitwise_and::gates_amount;
+                    }
+                };
+
+                static gate_manifest get_gate_manifest(std::size_t witness_amount, std::size_t lookup_column_amount,
+                                                       uint8_t m) {
+                    gate_manifest manifest = gate_manifest(gate_manifest_type());
+                    return manifest;
+                }
+
+                static manifest_type get_manifest(uint8_t m) {
+                    manifest_type manifest = manifest_type(
+                        std::shared_ptr<manifest_param>(new manifest_single_value_param(get_witness_columns(m))), true);
+                    return manifest;
+                }
+
+                static std::size_t get_rows_amount(std::size_t witness_amount, std::size_t lookup_column_amount,
+                                                   uint8_t m) {
+                    return M(m) < 4 ? 1 : 2;
+                }
+
+#ifdef TEST_WITHOUT_LOOKUP_TABLES
+                const static std::size_t gates_amount = 1;
+#else
+                const static std::size_t gates_amount = 2;
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+                const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, this->m);
+
+                struct input_type {
+                    var x = var(0, 0, false);
+                    var y = var(0, 0, false);
+
+                    std::vector<std::reference_wrapper<var>> all_vars() {
+                        return {x, y};
+                    }
+                };
+
+                struct result_type {
+                    var output = var(0, 0, false);
+                    result_type(const bitwise_and &component, std::uint32_t start_row_index) {
+                        const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                        output = var(splat(var_pos.z), false);
+                    }
+
+                    result_type(const bitwise_and &component, std::size_t start_row_index) {
+                        const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                        output = var(splat(var_pos.z), false);
+                    }
+
+                    std::vector<var> all_vars() const {
+                        return {output};
+                    }
+                };
+
+// Allows disabling lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result;
+                    auto table = std::shared_ptr<lookup_table_definition>(new bitwise_table());
+                    result.push_back(table);
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[bitwise_table::AND_TABLE_NAME] = 0;            // REQUIRED_TABLE
+                    lookup_tables[bitwise_table::SMALL_RANGE_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    return lookup_tables;
+                }
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+
+                template<typename ContainerType>
+                explicit bitwise_and(ContainerType witness, uint8_t m) :
+                    component_type(witness, {}, {}, get_manifest(m)), m(m) {};
+
+                template<typename WitnessContainerType, typename ConstantContainerType,
+                         typename PublicInputContainerType>
+                bitwise_and(WitnessContainerType witness, ConstantContainerType constant,
+                            PublicInputContainerType public_input, uint8_t m) :
+                    component_type(witness, constant, public_input, get_manifest(m)),
+                    m(m) {};
+
+                bitwise_and(std::initializer_list<typename component_type::witness_container_type::value_type>
+                                witnesses,
+                            std::initializer_list<typename component_type::constant_container_type::value_type>
+                                constants,
+                            std::initializer_list<typename component_type::public_input_container_type::value_type>
+                                public_inputs,
+                            uint8_t m) :
+                    component_type(witnesses, constants, public_inputs, get_manifest(m)),
+                    m(m) {};
+            };
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            using plonk_bitwise_and =
+                bitwise_and<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                            BlueprintFieldType, basic_non_native_policy<BlueprintFieldType>>;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams>::result_type generate_assignments(
+                const plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams> &component,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams>::input_type instance_input,
+                const std::uint32_t start_row_index) {
+
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                using var = typename plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams>::var;
+                using value_type = typename BlueprintFieldType::value_type;
+
+                auto m = component.get_m();
+                {
+                    value_type capacity = value_type::one();
+                    for (size_t i = 0; i < m; i++) {
+                        capacity = capacity * value_type(1ULL << 8);
+                    }
+                    BLUEPRINT_RELEASE_ASSERT(capacity < BitwiseHelper<BlueprintFieldType>::P_HALF);
+                }
+
+                auto one = value_type::one();
+                auto zero = value_type::zero();
+                value_type n_val = BitwiseHelper<BlueprintFieldType>::get_n(m);
+                assignment.constant(splat(var_pos.n)) = n_val;
+
+                auto x_val = var_value(assignment, instance_input.x);
+                auto y_val = var_value(assignment, instance_input.y);
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
+
+                std::vector<uint8_t> x0_val;
+                std::vector<uint8_t> y0_val;
+                value_type s_x_val;
+                value_type s_y_val;
+                value_type s_z_val;
+
+                s_x_val = BitwiseHelper<BlueprintFieldType>::decompose_bitwise(x_val, x0_val, m);
+                BLUEPRINT_RELEASE_ASSERT(x0_val.size() >= m);
+                s_y_val = BitwiseHelper<BlueprintFieldType>::decompose_bitwise(y_val, y0_val, m);
+                BLUEPRINT_RELEASE_ASSERT(y0_val.size() >= m);
+                // s_z == s_x * s_y == bitwise AND operation on 1-bit values
+                s_z_val = s_x_val * s_y_val;
+
+                assignment.witness(splat(var_pos.s_x)) = s_x_val;
+                assignment.witness(splat(var_pos.s_y)) = s_y_val;
+
+                std::vector<uint8_t> z0_val;
+                value_type z_val = s_z_val == one ? n_val : zero;
+                for (size_t i = 0; i < m; i++) {
+                    uint8_t result = x0_val[i] & y0_val[i];    // bitwise AND operation on 8-bit limbs
+                    z0_val.push_back(result);
+                    z_val = z_val + value_type(result) * value_type(1ULL << (8 * i));
+                }
+                assignment.witness(splat(var_pos.z)) = z_val;
+
+                assignment.witness(splat(var_pos.x0)) = x0_val[0];
+                assignment.witness(splat(var_pos.y0)) = y0_val[0];
+                assignment.witness(splat(var_pos.z0)) = z0_val[0];
+                for (size_t i = 1; i < m; i++) {
+                    assignment.witness(var_pos.x1.column() + i - 1, var_pos.x1.row()) = x0_val[i];
+                    assignment.witness(var_pos.y1.column() + i - 1, var_pos.y1.row()) = y0_val[i];
+                    assignment.witness(var_pos.z1.column() + i - 1, var_pos.z1.row()) = z0_val[i];
+                }
+
+                return typename plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_gates(
+                const plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+                using var = typename plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams>::var;
+                using value_type = typename BlueprintFieldType::value_type;
+                auto m = component.get_m();
+                {
+                    value_type capacity = value_type::one();
+                    for (size_t i = 0; i < m; i++) {
+                        capacity = capacity * value_type(1ULL << 8);
+                    }
+                    BLUEPRINT_RELEASE_ASSERT(capacity < BitwiseHelper<BlueprintFieldType>::P_HALF);
+                }
+
+                std::vector<crypto3::zk::snark::plonk_constraint<BlueprintFieldType>> constraints;
+
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto z = var(splat(var_pos.z));
+                auto s_x = var(splat(var_pos.s_x));
+                auto s_y = var(splat(var_pos.s_y));
+                // s_z == s_x * s_y == bitwise AND operation on 1-bit values
+                auto s_z = s_x * s_y;
+                auto n = var(splat(var_pos.n), true, var::column_type::constant);
+                auto x0 = nil::crypto3::math::expression(var(splat(var_pos.x0)));
+                auto y0 = nil::crypto3::math::expression(var(splat(var_pos.y0)));
+                auto z0 = nil::crypto3::math::expression(var(splat(var_pos.z0)));
+
+                // decomposition of x, y, z
+                for (size_t i = 1; i < m; i++) {
+                    x0 += var(var_pos.x1.column() + i - 1, var_pos.x1.row()) * (1ULL << (8 * i));
+                    y0 += var(var_pos.y1.column() + i - 1, var_pos.y1.row()) * (1ULL << (8 * i));
+                    z0 += var(var_pos.z1.column() + i - 1, var_pos.z1.row()) * (1ULL << (8 * i));
+                }
+                constraints.push_back(n * s_x + x0 - x);
+                constraints.push_back(n * s_y + y0 - y);
+                constraints.push_back(n * s_z + z0 - z);
+                constraints.push_back(s_x * (1 - s_x));
+                constraints.push_back(s_y * (1 - s_y));
+
+                return bp.add_gate(constraints);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            void generate_copy_constraints(
+                const plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams>::input_type &instance_input,
+                const std::size_t start_row_index) {
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                using var = typename plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams>::var;
+
+                auto x = var(splat(var_pos.x), false);
+                auto y = var(splat(var_pos.y), false);
+                bp.add_copy_constraint({instance_input.x, x});
+                bp.add_copy_constraint({instance_input.y, y});
+            }
+
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+
+                using value_type = typename BlueprintFieldType::value_type;
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m = component.get_m();
+
+                const auto &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+
+                using bitwise_table =
+                    typename plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams>::bitwise_table;
+
+                auto and_table_id = lookup_tables_indices.at(bitwise_table::AND_TABLE_NAME);
+
+                auto small_range_table_id = lookup_tables_indices.at(bitwise_table::SMALL_RANGE_TABLE_NAME);
+
+                std::vector<constraint_type> constraints;
+
+                // lookup small range table for x, y
+                {
+                    auto x0 = var(splat(var_pos.x0));
+                    constraint_type constraint;
+                    constraint.table_id = small_range_table_id;
+                    constraint.lookup_input = {x0};
+                    constraints.push_back(constraint);
+                }
+                {
+                    auto y0 = var(splat(var_pos.y0));
+                    constraint_type constraint;
+                    constraint.table_id = small_range_table_id;
+                    constraint.lookup_input = {y0};
+                    constraints.push_back(constraint);
+                }
+                for (size_t i = 1; i < m; i++) {
+                    {
+                        auto xi = var(var_pos.x1.column() + i - 1, var_pos.x1.row());
+                        constraint_type constraint;
+                        constraint.table_id = small_range_table_id;
+                        constraint.lookup_input = {xi};
+                        constraints.push_back(constraint);
+                    }
+                    {
+                        auto yi = var(var_pos.y1.column() + i - 1, var_pos.y1.row());
+                        constraint_type constraint;
+                        constraint.table_id = small_range_table_id;
+                        constraint.lookup_input = {yi};
+                        constraints.push_back(constraint);
+                    }
+                }
+
+                // lookup AND table for x, y, z
+                {
+                    auto x0 = var(splat(var_pos.x0));
+                    auto y0 = var(splat(var_pos.y0));
+                    auto z0 = var(splat(var_pos.z0));
+                    constraint_type constraint;
+                    constraint.table_id = and_table_id;
+                    constraint.lookup_input = {x0 * value_type(1ULL << 8) + y0, z0};
+                    constraints.push_back(constraint);
+                }
+                for (size_t i = 1; i < m; i++) {
+                    auto xi = var(var_pos.x1.column() + i - 1, var_pos.x1.row());
+                    auto yi = var(var_pos.y1.column() + i - 1, var_pos.y1.row());
+                    auto zi = var(var_pos.z1.column() + i - 1, var_pos.z1.row());
+                    constraint_type constraint;
+                    constraint.table_id = and_table_id;
+                    constraint.lookup_input = {xi * value_type(1ULL << 8) + yi, zi};
+                    constraints.push_back(constraint);
+                }
+
+                return bp.add_lookup_gate(constraints);
+            }
+
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams>::result_type generate_circuit(
+                const plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams>::input_type &instance_input,
+                const std::size_t start_row_index) {
+
+                std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
+
+// Allows disabling lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, start_row_index + component.rows_amount - 1);
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+                generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
+
+                return typename plonk_bitwise_and<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_BLUEPRINT_COMPONENTS_PLONK_FIELD_BITWISE_AND_HPP

--- a/include/nil/blueprint/components/algebra/fields/plonk/bitwise_or.hpp
+++ b/include/nil/blueprint/components/algebra/fields/plonk/bitwise_or.hpp
@@ -1,0 +1,511 @@
+#ifndef CRYPTO3_BLUEPRINT_COMPONENTS_PLONK_FIELD_BITWISE_OR_HPP
+#define CRYPTO3_BLUEPRINT_COMPONENTS_PLONK_FIELD_BITWISE_OR_HPP
+
+#include <nil/crypto3/zk/snark/arithmetization/plonk/constraint_system.hpp>
+
+#include <nil/blueprint/blueprint/plonk/assignment.hpp>
+#include <nil/blueprint/blueprint/plonk/circuit.hpp>
+#include <nil/blueprint/component.hpp>
+#include <nil/blueprint/manifest.hpp>
+#include <nil/blueprint/basic_non_native_policy.hpp>
+
+#include "nil/blueprint/components/cell_position.hpp"
+#include "nil/blueprint/components/algebra/fields/plonk/non_native/detail/bitwise_helper.hpp"
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+
+            // works via decomposing x and y into 8-bit limbs and one additional sign bit, and looking up the result of
+            // the bitwise operation for each 8-bit limb triples in a lookup table. The result is then reassembled from
+            // the lookup table result limbs.
+
+            /**
+             * Component representing a bitwise OR operation.
+             *
+             * Field elements greater than prime half are interpreted as negative numbers, similar to the repesentation
+             * of signed integers many in programming languages. The value of a field element gets deomposed into a
+             * dedicated sign bit and m 8-bit limbs and the bitwise operation gets applied to each pair of bits.
+             *
+             * Input:    x ... field element
+             *           y ... field element
+             * Output:   z ... x | y (field element)
+             * Constant: m ... number of 8-bit limbs (uint8_t), m in [1,8]
+             *           n ... negative part constant (field element), n = prime - 2^8m
+             */
+            template<typename ArithmetizationType, typename FieldType, typename NonNativePolicyType>
+            class bitwise_or;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams, typename NonNativePolicyType>
+            class bitwise_or<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                             BlueprintFieldType, NonNativePolicyType>
+                : public plonk_component<BlueprintFieldType, ArithmetizationParams, 1, 0> {
+
+            public:
+                using value_type = typename BlueprintFieldType::value_type;
+
+            private:
+                const uint8_t m;       // number of 8-bit limbs
+                const value_type n;    // negative part constant (field element): n = prime - 2^8m
+
+                static uint8_t M(uint8_t m) {
+                    if (m == 0 || m > 8) {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+                    return m;
+                }
+
+            public:
+                struct var_positions {
+                    CellPosition x, y, z, s_x, s_y, x0, x1, y0, y1, z0, z1, n;
+                    int64_t start_row;
+                };
+
+                var_positions get_var_pos(const int64_t start_row_index) const {
+
+                    auto m = this->m;
+                    var_positions pos;
+                    pos.start_row = start_row_index;
+                    pos.x = CellPosition(this->W(0), pos.start_row);
+                    pos.y = CellPosition(this->W(1), pos.start_row);
+                    pos.z = CellPosition(this->W(2), pos.start_row);
+                    pos.s_x = CellPosition(this->W(3), pos.start_row);
+                    pos.s_y = CellPosition(this->W(4), pos.start_row);
+                    pos.x0 = CellPosition(this->W(5 + (0 * m)), pos.start_row);    // occupies m cells
+                    pos.x1 = CellPosition(this->W(5 + (0 * m) + 1), pos.start_row);
+                    pos.n = CellPosition(this->C(0), pos.start_row);
+
+                    // trace layout constant (1 col(s), 1 row(s))
+                    //
+                    //     | constant |
+                    //  r\c|    0     |
+                    // +---+----------+
+                    // | 0 |    n     |
+
+                    if (rows_amount == 1) {
+                        // trace layout witness (1 col(s), 5 + 3m row(s))
+                        //
+                        //     |                                    witness                                     |
+                        //  r\c| 0 | 1 | 2 |  3  |  4  |  5  | .. | 5+m-1 | 5+m | .. | 5+2m-1| 5+2m| .. | 5+3m-1|
+                        // +---+---+---+---+-----+-----+-----+----+-------+-----+----+-------+-----+----+-------+
+                        // | 0 | x | y | z | s_x | s_y | x_0 | .. | x_m-1 | y_0 | .. | y_m-1 | z_0 | .. | z_m-1 |
+                        pos.y0 = CellPosition(this->W(5 + (1 * m)), pos.start_row);    // occupies m cells
+                        pos.y1 = CellPosition(this->W(5 + (1 * m) + 1), pos.start_row);
+                        pos.z0 = CellPosition(this->W(5 + (2 * m)), pos.start_row);    // occupies m cells
+                        pos.z1 = CellPosition(this->W(5 + (2 * m) + 1), pos.start_row);
+                    } else if (rows_amount == 2 && m < 8) {
+                        // trace layout witness (2 col(s), r row(s))
+                        // where r = max (m + 5, 2m)
+                        //
+                        //     |                 witness                  |
+                        //  r\c| 0 | 1 | 2 |  3  |  4  |  5  | .. | 5+m-1 |
+                        // +---+---+---+---+-----+-----+-----+----+-------+
+                        // | 0 | x | y | z | s_x | s_y | x_0 | .. | x_m-1 |
+
+                        //     |               witness               |
+                        //  r\c|  0  | .. |  m-1  |  m  | .. | 2m-1  |
+                        // +---+-----+----+-------+-----+----+-------+
+                        // | 1 | y_0 | .. | y_m-1 | z_0 | .. | z_m-1 |
+                        pos.y0 = CellPosition(this->W((0 * m)), pos.start_row + 1);    // occupies m cells
+                        pos.y1 = CellPosition(this->W((0 * m) + 1), pos.start_row + 1);
+                        pos.z0 = CellPosition(this->W((1 * m)), pos.start_row + 1);    // occupies m cells
+                        pos.z1 = CellPosition(this->W((1 * m) + 1), pos.start_row + 1);
+                    } else if (rows_amount == 2 && m == 8) {
+                        // trace layout witness (2 col(s), 15 row(s))
+                        //
+                        //     |                     witness                      |
+                        //  r\c| 0 | 1 | 2 |  3  |  4  |  5  | .. | 5+m-1 | 5 + m |
+                        // +---+---+---+---+-----+-----+-----+----+-------+-------+
+                        // | 0 | x | y | z | s_x | s_y | x_0 | .. | x_m-1 |  y_0  |
+
+                        //     |               witness               |
+                        //  r\c|  0  | .. |  m-2  | m-1 | .. | 2m-2  |
+                        // +---+-----+----+-------+-----+----+-------+
+                        // | 1 | y_1 | .. | y_m-1 | z_0 | .. | z_m-1 |
+                        pos.y0 = CellPosition(this->W(5 + m), pos.start_row);          // occupies 1 cell
+                        pos.y1 = CellPosition(this->W((0 * m)), pos.start_row + 1);    // occupies m-1 cells
+                        pos.z0 = CellPosition(this->W(m - 1), pos.start_row + 1);      // occupies m cells
+                        pos.z1 = CellPosition(this->W(m), pos.start_row + 1);
+                    } else {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+
+                    return pos;
+                }
+
+            public:
+                uint8_t get_m() const {
+                    return this->m;
+                }
+
+                static std::size_t get_witness_columns(uint8_t m) {
+                    if (3 * M(m) + 5 < 15) {
+                        return 3 * m + 5;
+                    } else if (m >= 4 && m < 8) {
+                        return std::max(m + 5, 2 * m);
+                    } else if (m == 8) {
+                        return 15;
+                    }
+                    BLUEPRINT_RELEASE_ASSERT(false);
+                    return 0;
+                }
+
+                using component_type = plonk_component<BlueprintFieldType, ArithmetizationParams, 1, 0>;
+
+                using var = typename component_type::var;
+                using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::lookup_table_definition<BlueprintFieldType>;
+                using bitwise_table = bitwise_table<BlueprintFieldType>;
+
+                class gate_manifest_type : public component_gate_manifest {
+                public:
+                    std::uint32_t gates_amount() const override {
+                        return bitwise_or::gates_amount;
+                    }
+                };
+
+                static gate_manifest get_gate_manifest(std::size_t witness_amount, std::size_t lookup_column_amount,
+                                                       uint8_t m) {
+                    gate_manifest manifest = gate_manifest(gate_manifest_type());
+                    return manifest;
+                }
+
+                static manifest_type get_manifest(uint8_t m) {
+                    manifest_type manifest = manifest_type(
+                        std::shared_ptr<manifest_param>(new manifest_single_value_param(get_witness_columns(m))), true);
+                    return manifest;
+                }
+
+                static std::size_t get_rows_amount(std::size_t witness_amount, std::size_t lookup_column_amount,
+                                                   uint8_t m) {
+                    return M(m) < 4 ? 1 : 2;
+                }
+
+#ifdef TEST_WITHOUT_LOOKUP_TABLES
+                const static std::size_t gates_amount = 1;
+#else
+                const static std::size_t gates_amount = 2;
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+                const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, this->m);
+
+                struct input_type {
+                    var x = var(0, 0, false);
+                    var y = var(0, 0, false);
+
+                    std::vector<std::reference_wrapper<var>> all_vars() {
+                        return {x, y};
+                    }
+                };
+
+                struct result_type {
+                    var output = var(0, 0, false);
+                    result_type(const bitwise_or &component, std::uint32_t start_row_index) {
+                        const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                        output = var(splat(var_pos.z), false);
+                    }
+
+                    result_type(const bitwise_or &component, std::size_t start_row_index) {
+                        const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                        output = var(splat(var_pos.z), false);
+                    }
+
+                    std::vector<var> all_vars() const {
+                        return {output};
+                    }
+                };
+
+// Allows disabling lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result;
+                    auto table = std::shared_ptr<lookup_table_definition>(new bitwise_table());
+                    result.push_back(table);
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[bitwise_table::OR_TABLE_NAME] = 0;             // REQUIRED_TABLE
+                    lookup_tables[bitwise_table::SMALL_RANGE_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    return lookup_tables;
+                }
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+
+                template<typename ContainerType>
+                explicit bitwise_or(ContainerType witness, uint8_t m) :
+                    component_type(witness, {}, {}, get_manifest(m)), m(m) {};
+
+                template<typename WitnessContainerType, typename ConstantContainerType,
+                         typename PublicInputContainerType>
+                bitwise_or(WitnessContainerType witness, ConstantContainerType constant,
+                           PublicInputContainerType public_input, uint8_t m) :
+                    component_type(witness, constant, public_input, get_manifest(m)),
+                    m(m) {};
+
+                bitwise_or(std::initializer_list<typename component_type::witness_container_type::value_type> witnesses,
+                           std::initializer_list<typename component_type::constant_container_type::value_type>
+                               constants,
+                           std::initializer_list<typename component_type::public_input_container_type::value_type>
+                               public_inputs,
+                           uint8_t m) :
+                    component_type(witnesses, constants, public_inputs, get_manifest(m)),
+                    m(m) {};
+            };
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            using plonk_bitwise_or =
+                bitwise_or<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                           BlueprintFieldType, basic_non_native_policy<BlueprintFieldType>>;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams>::result_type generate_assignments(
+                const plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams> &component,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams>::input_type instance_input,
+                const std::uint32_t start_row_index) {
+
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                using var = typename plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams>::var;
+                using value_type = typename BlueprintFieldType::value_type;
+
+                auto m = component.get_m();
+                {
+                    value_type capacity = value_type::one();
+                    for (size_t i = 0; i < m; i++) {
+                        capacity = capacity * value_type(1ULL << 8);
+                    }
+                    BLUEPRINT_RELEASE_ASSERT(capacity < BitwiseHelper<BlueprintFieldType>::P_HALF);
+                }
+
+                auto one = value_type::one();
+                auto zero = value_type::zero();
+                value_type n_val = BitwiseHelper<BlueprintFieldType>::get_n(m);
+                assignment.constant(splat(var_pos.n)) = n_val;
+
+                auto x_val = var_value(assignment, instance_input.x);
+                auto y_val = var_value(assignment, instance_input.y);
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
+
+                std::vector<uint8_t> x0_val;
+                std::vector<uint8_t> y0_val;
+                value_type s_x_val;
+                value_type s_y_val;
+                value_type s_z_val;
+
+                s_x_val = BitwiseHelper<BlueprintFieldType>::decompose_bitwise(x_val, x0_val, m);
+                BLUEPRINT_RELEASE_ASSERT(x0_val.size() >= m);
+                s_y_val = BitwiseHelper<BlueprintFieldType>::decompose_bitwise(y_val, y0_val, m);
+                BLUEPRINT_RELEASE_ASSERT(y0_val.size() >= m);
+                // s_z == s_x + s_y - s_x * s_y == bitwise OR operation on 1-bit values
+                s_z_val = s_x_val + s_y_val - s_x_val * s_y_val;
+
+                assignment.witness(splat(var_pos.s_x)) = s_x_val;
+                assignment.witness(splat(var_pos.s_y)) = s_y_val;
+
+                std::vector<uint8_t> z0_val;
+                value_type z_val = s_z_val == one ? n_val : zero;
+                for (size_t i = 0; i < m; i++) {
+                    uint8_t result = x0_val[i] | y0_val[i];    // bitwise OR operation on 8-bit limbs
+                    z0_val.push_back(result);
+                    z_val = z_val + value_type(result) * value_type(1ULL << (8 * i));
+                }
+                assignment.witness(splat(var_pos.z)) = z_val;
+
+                assignment.witness(splat(var_pos.x0)) = x0_val[0];
+                assignment.witness(splat(var_pos.y0)) = y0_val[0];
+                assignment.witness(splat(var_pos.z0)) = z0_val[0];
+                for (size_t i = 1; i < m; i++) {
+                    assignment.witness(var_pos.x1.column() + i - 1, var_pos.x1.row()) = x0_val[i];
+                    assignment.witness(var_pos.y1.column() + i - 1, var_pos.y1.row()) = y0_val[i];
+                    assignment.witness(var_pos.z1.column() + i - 1, var_pos.z1.row()) = z0_val[i];
+                }
+
+                return typename plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_gates(
+                const plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+                using var = typename plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams>::var;
+                using value_type = typename BlueprintFieldType::value_type;
+                auto m = component.get_m();
+                {
+                    value_type capacity = value_type::one();
+                    for (size_t i = 0; i < m; i++) {
+                        capacity = capacity * value_type(1ULL << 8);
+                    }
+                    BLUEPRINT_RELEASE_ASSERT(capacity < BitwiseHelper<BlueprintFieldType>::P_HALF);
+                }
+
+                std::vector<crypto3::zk::snark::plonk_constraint<BlueprintFieldType>> constraints;
+
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto z = var(splat(var_pos.z));
+                auto s_x = var(splat(var_pos.s_x));
+                auto s_y = var(splat(var_pos.s_y));
+                // s_z == s_x + s_y - s_x * s_y == bitwise OR operation on 1-bit values
+                auto s_z = s_x + s_y - s_x * s_y;
+                auto n = var(splat(var_pos.n), true, var::column_type::constant);
+                auto x0 = nil::crypto3::math::expression(var(splat(var_pos.x0)));
+                auto y0 = nil::crypto3::math::expression(var(splat(var_pos.y0)));
+                auto z0 = nil::crypto3::math::expression(var(splat(var_pos.z0)));
+
+                // decomposition of x, y, z
+                for (size_t i = 1; i < m; i++) {
+                    x0 += var(var_pos.x1.column() + i - 1, var_pos.x1.row()) * (1ULL << (8 * i));
+                    y0 += var(var_pos.y1.column() + i - 1, var_pos.y1.row()) * (1ULL << (8 * i));
+                    z0 += var(var_pos.z1.column() + i - 1, var_pos.z1.row()) * (1ULL << (8 * i));
+                }
+                constraints.push_back(n * s_x + x0 - x);
+                constraints.push_back(n * s_y + y0 - y);
+                constraints.push_back(n * s_z + z0 - z);
+                constraints.push_back(s_x * (1 - s_x));
+                constraints.push_back(s_y * (1 - s_y));
+
+                return bp.add_gate(constraints);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            void generate_copy_constraints(
+                const plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams>::input_type &instance_input,
+                const std::size_t start_row_index) {
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                using var = typename plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams>::var;
+
+                auto x = var(splat(var_pos.x), false);
+                auto y = var(splat(var_pos.y), false);
+                bp.add_copy_constraint({instance_input.x, x});
+                bp.add_copy_constraint({instance_input.y, y});
+            }
+
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+
+                using value_type = typename BlueprintFieldType::value_type;
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m = component.get_m();
+
+                const auto &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+
+                using bitwise_table =
+                    typename plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams>::bitwise_table;
+
+                auto or_table_id = lookup_tables_indices.at(bitwise_table::OR_TABLE_NAME);
+
+                auto small_range_table_id = lookup_tables_indices.at(bitwise_table::SMALL_RANGE_TABLE_NAME);
+
+                std::vector<constraint_type> constraints;
+
+                // lookup small range table for x, y
+                {
+                    auto x0 = var(splat(var_pos.x0));
+                    constraint_type constraint;
+                    constraint.table_id = small_range_table_id;
+                    constraint.lookup_input = {x0};
+                    constraints.push_back(constraint);
+                }
+                {
+                    auto y0 = var(splat(var_pos.y0));
+                    constraint_type constraint;
+                    constraint.table_id = small_range_table_id;
+                    constraint.lookup_input = {y0};
+                    constraints.push_back(constraint);
+                }
+                for (size_t i = 1; i < m; i++) {
+                    {
+                        auto xi = var(var_pos.x1.column() + i - 1, var_pos.x1.row());
+                        constraint_type constraint;
+                        constraint.table_id = small_range_table_id;
+                        constraint.lookup_input = {xi};
+                        constraints.push_back(constraint);
+                    }
+                    {
+                        auto yi = var(var_pos.y1.column() + i - 1, var_pos.y1.row());
+                        constraint_type constraint;
+                        constraint.table_id = small_range_table_id;
+                        constraint.lookup_input = {yi};
+                        constraints.push_back(constraint);
+                    }
+                }
+
+                // lookup AND table for x, y, z
+                {
+                    auto x0 = var(splat(var_pos.x0));
+                    auto y0 = var(splat(var_pos.y0));
+                    auto z0 = var(splat(var_pos.z0));
+                    constraint_type constraint;
+                    constraint.table_id = or_table_id;
+                    constraint.lookup_input = {x0 * value_type(1ULL << 8) + y0, z0};
+                    constraints.push_back(constraint);
+                }
+                for (size_t i = 1; i < m; i++) {
+                    auto xi = var(var_pos.x1.column() + i - 1, var_pos.x1.row());
+                    auto yi = var(var_pos.y1.column() + i - 1, var_pos.y1.row());
+                    auto zi = var(var_pos.z1.column() + i - 1, var_pos.z1.row());
+                    constraint_type constraint;
+                    constraint.table_id = or_table_id;
+                    constraint.lookup_input = {xi * value_type(1ULL << 8) + yi, zi};
+                    constraints.push_back(constraint);
+                }
+
+                return bp.add_lookup_gate(constraints);
+            }
+
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams>::result_type generate_circuit(
+                const plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams>::input_type &instance_input,
+                const std::size_t start_row_index) {
+
+                std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
+
+// Allows disabling lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, start_row_index + component.rows_amount - 1);
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+                generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
+
+                return typename plonk_bitwise_or<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_BLUEPRINT_COMPONENTS_PLONK_FIELD_BITWISE_OR_HPP

--- a/include/nil/blueprint/components/algebra/fields/plonk/bitwise_xor.hpp
+++ b/include/nil/blueprint/components/algebra/fields/plonk/bitwise_xor.hpp
@@ -1,0 +1,512 @@
+#ifndef CRYPTO3_BLUEPRINT_COMPONENTS_PLONK_FIELD_BITWISE_XOR_HPP
+#define CRYPTO3_BLUEPRINT_COMPONENTS_PLONK_FIELD_BITWISE_XOR_HPP
+
+#include <nil/crypto3/zk/snark/arithmetization/plonk/constraint_system.hpp>
+
+#include <nil/blueprint/blueprint/plonk/assignment.hpp>
+#include <nil/blueprint/blueprint/plonk/circuit.hpp>
+#include <nil/blueprint/component.hpp>
+#include <nil/blueprint/manifest.hpp>
+#include <nil/blueprint/basic_non_native_policy.hpp>
+
+#include "nil/blueprint/components/cell_position.hpp"
+#include "nil/blueprint/components/algebra/fields/plonk/non_native/detail/bitwise_helper.hpp"
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+
+            // works via decomposing x and y into 8-bit limbs and one additional sign bit, and looking up the result of
+            // the bitwise operation for each 8-bit limb triples in a lookup table. The result is then reassembled from
+            // the lookup table result limbs.
+
+            /**
+             * Component representing a bitwise XOR operation.
+             *
+             * Field elements greater than prime half are interpreted as negative numbers, similar to the repesentation
+             * of signed integers many in programming languages. The value of a field element gets deomposed into a
+             * dedicated sign bit and m 8-bit limbs and the bitwise operation gets applied to each pair of bits.
+             *
+             * Input:    x ... field element
+             *           y ... field element
+             * Output:   z ... x ^ y (field element)
+             * Constant: m ... number of 8-bit limbs (uint8_t), m in [1,8]
+             *           n ... negative part constant (field element), n = prime - 2^8m
+             */
+            template<typename ArithmetizationType, typename FieldType, typename NonNativePolicyType>
+            class bitwise_xor;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams, typename NonNativePolicyType>
+            class bitwise_xor<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                              BlueprintFieldType, NonNativePolicyType>
+                : public plonk_component<BlueprintFieldType, ArithmetizationParams, 1, 0> {
+
+            public:
+                using value_type = typename BlueprintFieldType::value_type;
+
+            private:
+                const uint8_t m;       // number of 8-bit limbs
+                const value_type n;    // negative part constant (field element): n = prime - 2^8m
+
+                static uint8_t M(uint8_t m) {
+                    if (m == 0 || m > 8) {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+                    return m;
+                }
+
+            public:
+                struct var_positions {
+                    CellPosition x, y, z, s_x, s_y, x0, x1, y0, y1, z0, z1, n;
+                    int64_t start_row;
+                };
+
+                var_positions get_var_pos(const int64_t start_row_index) const {
+
+                    auto m = this->m;
+                    var_positions pos;
+                    pos.start_row = start_row_index;
+                    pos.x = CellPosition(this->W(0), pos.start_row);
+                    pos.y = CellPosition(this->W(1), pos.start_row);
+                    pos.z = CellPosition(this->W(2), pos.start_row);
+                    pos.s_x = CellPosition(this->W(3), pos.start_row);
+                    pos.s_y = CellPosition(this->W(4), pos.start_row);
+                    pos.x0 = CellPosition(this->W(5 + (0 * m)), pos.start_row);    // occupies m cells
+                    pos.x1 = CellPosition(this->W(5 + (0 * m) + 1), pos.start_row);
+                    pos.n = CellPosition(this->C(0), pos.start_row);
+
+                    // trace layout constant (1 col(s), 1 row(s))
+                    //
+                    //     | constant |
+                    //  r\c|    0     |
+                    // +---+----------+
+                    // | 0 |    n     |
+
+                    if (rows_amount == 1) {
+                        // trace layout witness (1 col(s), 5 + 3m row(s))
+                        //
+                        //     |                                    witness                                     |
+                        //  r\c| 0 | 1 | 2 |  3  |  4  |  5  | .. | 5+m-1 | 5+m | .. | 5+2m-1| 5+2m| .. | 5+3m-1|
+                        // +---+---+---+---+-----+-----+-----+----+-------+-----+----+-------+-----+----+-------+
+                        // | 0 | x | y | z | s_x | s_y | x_0 | .. | x_m-1 | y_0 | .. | y_m-1 | z_0 | .. | z_m-1 |
+                        pos.y0 = CellPosition(this->W(5 + (1 * m)), pos.start_row);    // occupies m cells
+                        pos.y1 = CellPosition(this->W(5 + (1 * m) + 1), pos.start_row);
+                        pos.z0 = CellPosition(this->W(5 + (2 * m)), pos.start_row);    // occupies m cells
+                        pos.z1 = CellPosition(this->W(5 + (2 * m) + 1), pos.start_row);
+                    } else if (rows_amount == 2 && m < 8) {
+                        // trace layout witness (2 col(s), r row(s))
+                        // where r = max (m + 5, 2m)
+                        //
+                        //     |                 witness                  |
+                        //  r\c| 0 | 1 | 2 |  3  |  4  |  5  | .. | 5+m-1 |
+                        // +---+---+---+---+-----+-----+-----+----+-------+
+                        // | 0 | x | y | z | s_x | s_y | x_0 | .. | x_m-1 |
+
+                        //     |               witness               |
+                        //  r\c|  0  | .. |  m-1  |  m  | .. | 2m-1  |
+                        // +---+-----+----+-------+-----+----+-------+
+                        // | 1 | y_0 | .. | y_m-1 | z_0 | .. | z_m-1 |
+                        pos.y0 = CellPosition(this->W((0 * m)), pos.start_row + 1);    // occupies m cells
+                        pos.y1 = CellPosition(this->W((0 * m) + 1), pos.start_row + 1);
+                        pos.z0 = CellPosition(this->W((1 * m)), pos.start_row + 1);    // occupies m cells
+                        pos.z1 = CellPosition(this->W((1 * m) + 1), pos.start_row + 1);
+                    } else if (rows_amount == 2 && m == 8) {
+                        // trace layout witness (2 col(s), 15 row(s))
+                        //
+                        //     |                     witness                      |
+                        //  r\c| 0 | 1 | 2 |  3  |  4  |  5  | .. | 5+m-1 | 5 + m |
+                        // +---+---+---+---+-----+-----+-----+----+-------+-------+
+                        // | 0 | x | y | z | s_x | s_y | x_0 | .. | x_m-1 |  y_0  |
+
+                        //     |               witness               |
+                        //  r\c|  0  | .. |  m-2  | m-1 | .. | 2m-2  |
+                        // +---+-----+----+-------+-----+----+-------+
+                        // | 1 | y_1 | .. | y_m-1 | z_0 | .. | z_m-1 |
+                        pos.y0 = CellPosition(this->W(5 + m), pos.start_row);          // occupies 1 cell
+                        pos.y1 = CellPosition(this->W((0 * m)), pos.start_row + 1);    // occupies m-1 cells
+                        pos.z0 = CellPosition(this->W(m - 1), pos.start_row + 1);      // occupies m cells
+                        pos.z1 = CellPosition(this->W(m), pos.start_row + 1);
+                    } else {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+
+                    return pos;
+                }
+
+            public:
+                uint8_t get_m() const {
+                    return this->m;
+                }
+
+                static std::size_t get_witness_columns(uint8_t m) {
+                    if (3 * M(m) + 5 < 15) {
+                        return 3 * m + 5;
+                    } else if (m >= 4 && m < 8) {
+                        return std::max(m + 5, 2 * m);
+                    } else if (m == 8) {
+                        return 15;
+                    }
+                    BLUEPRINT_RELEASE_ASSERT(false);
+                    return 0;
+                }
+
+                using component_type = plonk_component<BlueprintFieldType, ArithmetizationParams, 1, 0>;
+
+                using var = typename component_type::var;
+                using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::lookup_table_definition<BlueprintFieldType>;
+                using bitwise_table = bitwise_table<BlueprintFieldType>;
+
+                class gate_manifest_type : public component_gate_manifest {
+                public:
+                    std::uint32_t gates_amount() const override {
+                        return bitwise_xor::gates_amount;
+                    }
+                };
+
+                static gate_manifest get_gate_manifest(std::size_t witness_amount, std::size_t lookup_column_amount,
+                                                       uint8_t m) {
+                    gate_manifest manifest = gate_manifest(gate_manifest_type());
+                    return manifest;
+                }
+
+                static manifest_type get_manifest(uint8_t m) {
+                    manifest_type manifest = manifest_type(
+                        std::shared_ptr<manifest_param>(new manifest_single_value_param(get_witness_columns(m))), true);
+                    return manifest;
+                }
+
+                static std::size_t get_rows_amount(std::size_t witness_amount, std::size_t lookup_column_amount,
+                                                   uint8_t m) {
+                    return M(m) < 4 ? 1 : 2;
+                }
+
+#ifdef TEST_WITHOUT_LOOKUP_TABLES
+                const static std::size_t gates_amount = 1;
+#else
+                const static std::size_t gates_amount = 2;
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+                const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, this->m);
+
+                struct input_type {
+                    var x = var(0, 0, false);
+                    var y = var(0, 0, false);
+
+                    std::vector<std::reference_wrapper<var>> all_vars() {
+                        return {x, y};
+                    }
+                };
+
+                struct result_type {
+                    var output = var(0, 0, false);
+                    result_type(const bitwise_xor &component, std::uint32_t start_row_index) {
+                        const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                        output = var(splat(var_pos.z), false);
+                    }
+
+                    result_type(const bitwise_xor &component, std::size_t start_row_index) {
+                        const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                        output = var(splat(var_pos.z), false);
+                    }
+
+                    std::vector<var> all_vars() const {
+                        return {output};
+                    }
+                };
+
+// Allows disabling lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result;
+                    auto table = std::shared_ptr<lookup_table_definition>(new bitwise_table());
+                    result.push_back(table);
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[bitwise_table::XOR_TABLE_NAME] = 0;            // REQUIRED_TABLE
+                    lookup_tables[bitwise_table::SMALL_RANGE_TABLE_NAME] = 0;    // REQUIRED_TABLE
+                    return lookup_tables;
+                }
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+
+                template<typename ContainerType>
+                explicit bitwise_xor(ContainerType witness, uint8_t m) :
+                    component_type(witness, {}, {}, get_manifest(m)), m(m) {};
+
+                template<typename WitnessContainerType, typename ConstantContainerType,
+                         typename PublicInputContainerType>
+                bitwise_xor(WitnessContainerType witness, ConstantContainerType constant,
+                            PublicInputContainerType public_input, uint8_t m) :
+                    component_type(witness, constant, public_input, get_manifest(m)),
+                    m(m) {};
+
+                bitwise_xor(std::initializer_list<typename component_type::witness_container_type::value_type>
+                                witnesses,
+                            std::initializer_list<typename component_type::constant_container_type::value_type>
+                                constants,
+                            std::initializer_list<typename component_type::public_input_container_type::value_type>
+                                public_inputs,
+                            uint8_t m) :
+                    component_type(witnesses, constants, public_inputs, get_manifest(m)),
+                    m(m) {};
+            };
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            using plonk_bitwise_xor =
+                bitwise_xor<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                            BlueprintFieldType, basic_non_native_policy<BlueprintFieldType>>;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams>::result_type generate_assignments(
+                const plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams> &component,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams>::input_type instance_input,
+                const std::uint32_t start_row_index) {
+
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                using var = typename plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams>::var;
+                using value_type = typename BlueprintFieldType::value_type;
+
+                auto m = component.get_m();
+                {
+                    value_type capacity = value_type::one();
+                    for (size_t i = 0; i < m; i++) {
+                        capacity = capacity * value_type(1ULL << 8);
+                    }
+                    BLUEPRINT_RELEASE_ASSERT(capacity < BitwiseHelper<BlueprintFieldType>::P_HALF);
+                }
+
+                auto one = value_type::one();
+                auto zero = value_type::zero();
+                value_type n_val = BitwiseHelper<BlueprintFieldType>::get_n(m);
+                assignment.constant(splat(var_pos.n)) = n_val;
+
+                auto x_val = var_value(assignment, instance_input.x);
+                auto y_val = var_value(assignment, instance_input.y);
+                assignment.witness(splat(var_pos.x)) = x_val;
+                assignment.witness(splat(var_pos.y)) = y_val;
+
+                std::vector<uint8_t> x0_val;
+                std::vector<uint8_t> y0_val;
+                value_type s_x_val;
+                value_type s_y_val;
+                value_type s_z_val;
+
+                s_x_val = BitwiseHelper<BlueprintFieldType>::decompose_bitwise(x_val, x0_val, m);
+                BLUEPRINT_RELEASE_ASSERT(x0_val.size() >= m);
+                s_y_val = BitwiseHelper<BlueprintFieldType>::decompose_bitwise(y_val, y0_val, m);
+                BLUEPRINT_RELEASE_ASSERT(y0_val.size() >= m);
+                // s_z == (one - s_x * s_y) * (s_x + s_y) == bitwise XOR operation on 1-bit values
+                s_z_val = (one - s_x_val * s_y_val) * (s_x_val + s_y_val);
+
+                assignment.witness(splat(var_pos.s_x)) = s_x_val;
+                assignment.witness(splat(var_pos.s_y)) = s_y_val;
+
+                std::vector<uint8_t> z0_val;
+                value_type z_val = s_z_val == one ? n_val : zero;
+                for (size_t i = 0; i < m; i++) {
+                    uint8_t result = x0_val[i] ^ y0_val[i];    // bitwise XOR operation on 8-bit limbs
+                    z0_val.push_back(result);
+                    z_val = z_val + value_type(result) * value_type(1ULL << (8 * i));
+                }
+                assignment.witness(splat(var_pos.z)) = z_val;
+
+                assignment.witness(splat(var_pos.x0)) = x0_val[0];
+                assignment.witness(splat(var_pos.y0)) = y0_val[0];
+                assignment.witness(splat(var_pos.z0)) = z0_val[0];
+                for (size_t i = 1; i < m; i++) {
+                    assignment.witness(var_pos.x1.column() + i - 1, var_pos.x1.row()) = x0_val[i];
+                    assignment.witness(var_pos.y1.column() + i - 1, var_pos.y1.row()) = y0_val[i];
+                    assignment.witness(var_pos.z1.column() + i - 1, var_pos.z1.row()) = z0_val[i];
+                }
+
+                return typename plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_gates(
+                const plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+                using var = typename plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams>::var;
+                using value_type = typename BlueprintFieldType::value_type;
+                auto m = component.get_m();
+                {
+                    value_type capacity = value_type::one();
+                    for (size_t i = 0; i < m; i++) {
+                        capacity = capacity * value_type(1ULL << 8);
+                    }
+                    BLUEPRINT_RELEASE_ASSERT(capacity < BitwiseHelper<BlueprintFieldType>::P_HALF);
+                }
+
+                std::vector<crypto3::zk::snark::plonk_constraint<BlueprintFieldType>> constraints;
+
+                auto x = var(splat(var_pos.x));
+                auto y = var(splat(var_pos.y));
+                auto z = var(splat(var_pos.z));
+                auto s_x = var(splat(var_pos.s_x));
+                auto s_y = var(splat(var_pos.s_y));
+                // s_z == (1 - s_x * s_y) * (s_x + s_y) == bitwise XOR operation on 1-bit values
+                auto s_z = (1 - s_x * s_y) * (s_x + s_y);
+                auto n = var(splat(var_pos.n), true, var::column_type::constant);
+                auto x0 = nil::crypto3::math::expression(var(splat(var_pos.x0)));
+                auto y0 = nil::crypto3::math::expression(var(splat(var_pos.y0)));
+                auto z0 = nil::crypto3::math::expression(var(splat(var_pos.z0)));
+
+                // decomposition of x, y, z
+                for (size_t i = 1; i < m; i++) {
+                    x0 += var(var_pos.x1.column() + i - 1, var_pos.x1.row()) * (1ULL << (8 * i));
+                    y0 += var(var_pos.y1.column() + i - 1, var_pos.y1.row()) * (1ULL << (8 * i));
+                    z0 += var(var_pos.z1.column() + i - 1, var_pos.z1.row()) * (1ULL << (8 * i));
+                }
+                constraints.push_back(n * s_x + x0 - x);
+                constraints.push_back(n * s_y + y0 - y);
+                constraints.push_back(n * s_z + z0 - z);
+                constraints.push_back(s_x * (1 - s_x));
+                constraints.push_back(s_y * (1 - s_y));
+
+                return bp.add_gate(constraints);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            void generate_copy_constraints(
+                const plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams>::input_type &instance_input,
+                const std::size_t start_row_index) {
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                using var = typename plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams>::var;
+
+                auto x = var(splat(var_pos.x), false);
+                auto y = var(splat(var_pos.y), false);
+                bp.add_copy_constraint({instance_input.x, x});
+                bp.add_copy_constraint({instance_input.y, y});
+            }
+
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+
+                using value_type = typename BlueprintFieldType::value_type;
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m = component.get_m();
+
+                const auto &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+
+                using bitwise_table =
+                    typename plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams>::bitwise_table;
+
+                auto xor_table_id = lookup_tables_indices.at(bitwise_table::XOR_TABLE_NAME);
+
+                auto small_range_table_id = lookup_tables_indices.at(bitwise_table::SMALL_RANGE_TABLE_NAME);
+
+                std::vector<constraint_type> constraints;
+
+                // lookup small range table for x, y
+                {
+                    auto x0 = var(splat(var_pos.x0));
+                    constraint_type constraint;
+                    constraint.table_id = small_range_table_id;
+                    constraint.lookup_input = {x0};
+                    constraints.push_back(constraint);
+                }
+                {
+                    auto y0 = var(splat(var_pos.y0));
+                    constraint_type constraint;
+                    constraint.table_id = small_range_table_id;
+                    constraint.lookup_input = {y0};
+                    constraints.push_back(constraint);
+                }
+                for (size_t i = 1; i < m; i++) {
+                    {
+                        auto xi = var(var_pos.x1.column() + i - 1, var_pos.x1.row());
+                        constraint_type constraint;
+                        constraint.table_id = small_range_table_id;
+                        constraint.lookup_input = {xi};
+                        constraints.push_back(constraint);
+                    }
+                    {
+                        auto yi = var(var_pos.y1.column() + i - 1, var_pos.y1.row());
+                        constraint_type constraint;
+                        constraint.table_id = small_range_table_id;
+                        constraint.lookup_input = {yi};
+                        constraints.push_back(constraint);
+                    }
+                }
+
+                // lookup AND table for x, y, z
+                {
+                    auto x0 = var(splat(var_pos.x0));
+                    auto y0 = var(splat(var_pos.y0));
+                    auto z0 = var(splat(var_pos.z0));
+                    constraint_type constraint;
+                    constraint.table_id = xor_table_id;
+                    constraint.lookup_input = {x0 * value_type(1ULL << 8) + y0, z0};
+                    constraints.push_back(constraint);
+                }
+                for (size_t i = 1; i < m; i++) {
+                    auto xi = var(var_pos.x1.column() + i - 1, var_pos.x1.row());
+                    auto yi = var(var_pos.y1.column() + i - 1, var_pos.y1.row());
+                    auto zi = var(var_pos.z1.column() + i - 1, var_pos.z1.row());
+                    constraint_type constraint;
+                    constraint.table_id = xor_table_id;
+                    constraint.lookup_input = {xi * value_type(1ULL << 8) + yi, zi};
+                    constraints.push_back(constraint);
+                }
+
+                return bp.add_lookup_gate(constraints);
+            }
+
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams>::result_type generate_circuit(
+                const plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams>::input_type &instance_input,
+                const std::size_t start_row_index) {
+
+                std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
+
+// Allows disabling lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, start_row_index + component.rows_amount - 1);
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+                generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
+
+                return typename plonk_bitwise_xor<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_BLUEPRINT_COMPONENTS_PLONK_FIELD_BITWISE_XOR_HPP

--- a/include/nil/blueprint/components/algebra/fields/plonk/non_native/detail/bitwise_helper.hpp
+++ b/include/nil/blueprint/components/algebra/fields/plonk/non_native/detail/bitwise_helper.hpp
@@ -1,0 +1,251 @@
+#ifndef CRYPTO3_BLUEPRINT_COMPONENTS_PLONK_FIELD_BITWISE_OPS_HELPER_HPP
+#define CRYPTO3_BLUEPRINT_COMPONENTS_PLONK_FIELD_BITWISE_OPS_HELPER_HPP
+
+#include <cstdint>
+#include <cmath>
+
+#include <nil/blueprint/assert.hpp>
+#include <nil/crypto3/multiprecision/cpp_int/divide.hpp>
+#include <nil/crypto3/multiprecision/cpp_bin_float.hpp>
+#include <nil/crypto3/multiprecision/detail/default_ops.hpp>
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+
+            template<typename BlueprintFieldType>
+            class BitwiseTables {
+                using value_type = typename BlueprintFieldType::value_type;
+
+                static std::vector<value_type> fill_range_table();
+
+                static std::vector<value_type> fill_bitwise_and_table();
+                static std::vector<value_type> fill_bitwise_xor_table();
+                static std::vector<value_type> fill_bitwise_or_table();
+
+            public:
+                BitwiseTables() = delete;
+                BitwiseTables(const BitwiseTables &) = delete;
+                BitwiseTables &operator=(const BitwiseTables &) = delete;
+
+                static constexpr uint32_t RANGE_LEN = (1ULL << 16);
+                static constexpr uint32_t SMALL_RANGE_LEN = (1ULL << 8);
+
+                static constexpr uint16_t BITWISE_CHUNK_BITSIZE = 8;
+                static constexpr uint32_t BITWISE_CHUNK_LEN = (1ULL << BITWISE_CHUNK_BITSIZE);
+                static constexpr uint32_t BITWISE_TABLE_LEN = (1ULL << (2 * BITWISE_CHUNK_BITSIZE));
+
+                static const std::vector<value_type> &get_range_table();
+
+                static const std::vector<value_type> &get_bitwise_and_table();
+                static const std::vector<value_type> &get_bitwise_xor_table();
+                static const std::vector<value_type> &get_bitwise_or_table();
+            };
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename BitwiseTables<BlueprintFieldType>::value_type> &
+                BitwiseTables<BlueprintFieldType>::get_range_table() {
+                static std::vector<value_type> range = fill_range_table();
+                return range;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename BitwiseTables<BlueprintFieldType>::value_type> &
+                BitwiseTables<BlueprintFieldType>::get_bitwise_and_table() {
+                static std::vector<value_type> bitwise_and = fill_bitwise_and_table();
+                return bitwise_and;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename BitwiseTables<BlueprintFieldType>::value_type> &
+                BitwiseTables<BlueprintFieldType>::get_bitwise_xor_table() {
+                static std::vector<value_type> bitwise_xor = fill_bitwise_xor_table();
+                return bitwise_xor;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename BitwiseTables<BlueprintFieldType>::value_type> &
+                BitwiseTables<BlueprintFieldType>::get_bitwise_or_table() {
+                static std::vector<value_type> bitwise_or = fill_bitwise_or_table();
+                return bitwise_or;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename BitwiseTables<BlueprintFieldType>::value_type>
+                BitwiseTables<BlueprintFieldType>::fill_range_table() {
+                std::vector<value_type> range;
+                range.reserve(RANGE_LEN);
+                for (auto i = 0; i < RANGE_LEN; ++i) {
+                    range.push_back(value_type(i));
+                }
+                return range;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename BitwiseTables<BlueprintFieldType>::value_type>
+                BitwiseTables<BlueprintFieldType>::fill_bitwise_and_table() {
+                BLUEPRINT_RELEASE_ASSERT(BITWISE_TABLE_LEN == RANGE_LEN);
+                std::vector<value_type> bitwise_and;
+                bitwise_and.reserve(BITWISE_TABLE_LEN);
+                for (auto i = 0; i < BITWISE_CHUNK_LEN; ++i) {
+                    for (auto j = 0; j < BITWISE_CHUNK_LEN; ++j) {
+                        bitwise_and.push_back(value_type(i & j));
+                    }
+                }
+                BLUEPRINT_RELEASE_ASSERT(bitwise_and.size() == BITWISE_TABLE_LEN);
+                return bitwise_and;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename BitwiseTables<BlueprintFieldType>::value_type>
+                BitwiseTables<BlueprintFieldType>::fill_bitwise_xor_table() {
+                BLUEPRINT_RELEASE_ASSERT(BITWISE_TABLE_LEN == RANGE_LEN);
+                std::vector<value_type> bitwise_xor;
+                bitwise_xor.reserve(BITWISE_TABLE_LEN);
+                for (auto i = 0; i < BITWISE_CHUNK_LEN; ++i) {
+                    for (auto j = 0; j < BITWISE_CHUNK_LEN; ++j) {
+                        bitwise_xor.push_back(value_type(i ^ j));
+                    }
+                }
+                BLUEPRINT_RELEASE_ASSERT(bitwise_xor.size() == BITWISE_TABLE_LEN);
+                return bitwise_xor;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename BitwiseTables<BlueprintFieldType>::value_type>
+                BitwiseTables<BlueprintFieldType>::fill_bitwise_or_table() {
+                BLUEPRINT_RELEASE_ASSERT(BITWISE_TABLE_LEN == RANGE_LEN);
+                std::vector<value_type> bitwise_or;
+                bitwise_or.reserve(BITWISE_TABLE_LEN);
+                for (auto i = 0; i < BITWISE_CHUNK_LEN; ++i) {
+                    for (auto j = 0; j < BITWISE_CHUNK_LEN; ++j) {
+                        bitwise_or.push_back(value_type(i | j));
+                    }
+                }
+                BLUEPRINT_RELEASE_ASSERT(bitwise_or.size() == BITWISE_TABLE_LEN);
+                return bitwise_or;
+            }
+
+            template<typename BlueprintFieldType>
+            class bitwise_table : public nil::crypto3::zk::snark::lookup_table_definition<BlueprintFieldType> {
+
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::lookup_table_definition<BlueprintFieldType>;
+                using bitwise_tables = BitwiseTables<BlueprintFieldType>;
+
+            public:
+                static constexpr const char *TABLE_NAME = "bitwise_table";
+
+                static constexpr const char *AND_SUBTABLE_NAME = "and";
+                static constexpr const char *AND_TABLE_NAME = "bitwise_table/and";
+
+                static constexpr const char *XOR_SUBTABLE_NAME = "xor";
+                static constexpr const char *XOR_TABLE_NAME = "bitwise_table/xor";
+
+                static constexpr const char *OR_SUBTABLE_NAME = "or";
+                static constexpr const char *OR_TABLE_NAME = "bitwise_table/or";
+
+                static constexpr const char *SMALL_RANGE_SUBTABLE_NAME = "small_range";
+                static constexpr const char *SMALL_RANGE_TABLE_NAME = "bitwise_table/small_range";
+
+                bitwise_table() : lookup_table_definition(TABLE_NAME) {
+                    this->subtables[AND_SUBTABLE_NAME] = {{0, 1}, 0, bitwise_tables::BITWISE_TABLE_LEN - 1};
+                    this->subtables[XOR_SUBTABLE_NAME] = {{0, 2}, 0, bitwise_tables::BITWISE_TABLE_LEN - 1};
+                    this->subtables[OR_SUBTABLE_NAME] = {{0, 3}, 0, bitwise_tables::BITWISE_TABLE_LEN - 1};
+                    this->subtables[SMALL_RANGE_SUBTABLE_NAME] = {{0}, 0, bitwise_tables::SMALL_RANGE_LEN - 1};
+                }
+
+                virtual void generate() {
+                    auto input = bitwise_tables::get_range_table();
+                    auto output_and = bitwise_tables::get_bitwise_and_table();
+                    auto output_xor = bitwise_tables::get_bitwise_xor_table();
+                    auto output_or = bitwise_tables::get_bitwise_or_table();
+                    this->_table = {input, output_and, output_xor, output_or};
+                }
+
+                virtual std::size_t get_columns_number() {
+                    return 4;
+                }
+
+                virtual std::size_t get_rows_number() {
+                    return bitwise_tables::BITWISE_TABLE_LEN;
+                }
+            };
+
+            template<typename BlueprintFieldType>
+            class BitwiseHelper {
+            public:
+                using value_type = typename BlueprintFieldType::value_type;
+                using modular_backend = typename BlueprintFieldType::modular_backend;
+
+                // modulus is cpp_int_backend, so /2 is integer division and not field divison
+                static constexpr value_type P_HALF = BlueprintFieldType::modulus / 2;
+
+                // Transforms from/to montgomery representation
+                static modular_backend field_to_backend(const value_type &);
+
+                // Returns the sign bit (1 if the number is "negative" (i.e. >= P/2), 0 otherwise)
+                static value_type sign(const value_type &);
+                // computes n = modulus - 2^(8*m)
+                static value_type get_n(uint8_t m);
+                // Returns sign bit and decomposes a field element into 8-bit limbs for bitwise operations
+                static value_type decompose_bitwise(const value_type &, std::vector<uint8_t> &, uint8_t);
+            };
+
+            template<typename BlueprintFieldType>
+            typename BitwiseHelper<BlueprintFieldType>::modular_backend
+                BitwiseHelper<BlueprintFieldType>::field_to_backend(const value_type &x) {
+                modular_backend out;
+                BlueprintFieldType::modulus_params.adjust_regular(out, x.data.backend().base_data());
+                BLUEPRINT_RELEASE_ASSERT(out.size() != 0);
+                return out;
+            }
+
+            template<typename BlueprintFieldType>
+            typename BlueprintFieldType::value_type BitwiseHelper<BlueprintFieldType>::sign(const value_type &x) {
+                if (x > P_HALF) {
+                    return value_type(1);
+                }
+                return value_type(0);
+            }
+
+            template<typename BlueprintFieldType>
+            typename BlueprintFieldType::value_type BitwiseHelper<BlueprintFieldType>::get_n(uint8_t m) {
+                BLUEPRINT_RELEASE_ASSERT(0 < m && m <= 8);
+                if (m == 8) {
+                    return BlueprintFieldType::modulus - value_type(1ULL << (8 * 4)) * value_type(1ULL << (8 * 4));
+                }    // else 0 < m && m <= 7
+                return BlueprintFieldType::modulus - value_type(1ULL << (8 * m));
+            }
+
+            template<typename BlueprintFieldType>
+            typename BlueprintFieldType::value_type
+                BitwiseHelper<BlueprintFieldType>::decompose_bitwise(const value_type &inp,
+                                                                     std::vector<uint8_t> &output, uint8_t m) {
+                BLUEPRINT_RELEASE_ASSERT(0 < m && m <= 8);
+                output.clear();
+                output.reserve(m);
+
+                value_type inp_sign = sign(inp);
+
+                // n is zero for "positive" values of inp and modulus - 2^(8*m) for "negative" values of inp
+                value_type n = inp_sign == value_type::zero() ? value_type::zero() : get_n(m);
+
+                // need to transform input to correctly handle "negative" values of inp
+                auto transformed_inp = inp - n;
+                auto tmp = field_to_backend(transformed_inp);
+                for (auto i = 0; i < tmp.size(); i++) {
+                    for (auto j = 0; j < 4; j++) {
+                        output.push_back(static_cast<uint8_t>(tmp.limbs()[i] & 0xFF));
+                        output.push_back(static_cast<uint8_t>(tmp.limbs()[i] >> 8));
+                        tmp.limbs()[i] >>= 16;
+                    }
+                }
+                return inp_sign;
+            }
+
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_BLUEPRINT_COMPONENTS_PLONK_FIELD_BITWISE_OPS_HELPER_HPP

--- a/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp
@@ -20,12 +20,13 @@ namespace nil {
 
             public:
                 static constexpr const char *TABLE_NAME = "fixedpoint_range_table";
-                static constexpr const char *SUBTABLE_NAME = "full";
+
+                static constexpr const char *FULL_SUBTABLE_NAME = "full";
                 static constexpr const char *FULL_TABLE_NAME = "fixedpoint_range_table/full";
 
                 // TACEO_TODO this hardcoded 0 is probably wrong
                 fixedpoint_range_table() : lookup_table_definition(TABLE_NAME) {
-                    this->subtables[SUBTABLE_NAME] = {{0}, 0, fixedpoint_tables::RangeLen - 1};
+                    this->subtables[FULL_SUBTABLE_NAME] = {{0}, 0, fixedpoint_tables::RangeLen - 1};
                 }
 
                 virtual void generate() {

--- a/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/tester.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/tester.hpp
@@ -16,6 +16,109 @@ namespace nil {
         }
 
         template<typename BlueprintFieldType, typename ArithmetizationParams>
+        bool check_lookup_constraint(
+            circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+            const assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                &assignment,
+            crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType> &constraint, int row) {
+
+            using value_type = typename BlueprintFieldType::value_type;
+            using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
+
+            // The tables
+            auto &lookup_tables = bp.get_reserved_tables();
+            auto &indices = bp.get_reserved_indices();
+
+            auto table_id = constraint.table_id;
+            auto &lookup_input = constraint.lookup_input;
+
+            // Get lookup table
+            std::string name = "";
+            for (auto el : indices) {
+                if (el.second == table_id) {
+                    name = el.first;
+                    break;
+                }
+            }
+
+            // Get the lookup values
+            std::vector<value_type> lookup_values;
+            lookup_values.reserve(lookup_input.size());
+            for (auto &t : lookup_input) {
+                if (t.get_expr().which() != 0) {
+                    std::cout << "Skipping check of lookup table with ID \"" << name << "\" at row " << row
+                              << " as there exist lookup inputs that are not a single variable" << std::endl;
+                    return true;
+                }
+                nil::crypto3::math::term<var> term = boost::get<nil::crypto3::math::term<var>>(t.get_expr());
+                BLUEPRINT_RELEASE_ASSERT(term.get_vars().size() == 1);
+                var val = term.get_vars()[0];
+                val.rotation += row;
+                auto value = var_value(assignment, val);
+                lookup_values.push_back(value);
+            }
+
+            BLUEPRINT_RELEASE_ASSERT(name != "");
+            auto index = name.find("/");
+            BLUEPRINT_RELEASE_ASSERT(index != -1);
+            auto tab_name = name.substr(0, index);
+            auto sub_name = name.substr(index + 1);
+
+            auto &table = lookup_tables.at(tab_name);
+            auto &table_vals = table->get_table();
+            auto &subtable = table->subtables.at(sub_name);
+
+            BLUEPRINT_RELEASE_ASSERT(subtable.column_indices.size() == lookup_values.size());
+
+            // Compare to the actual table
+            auto row_index = -1;
+            auto first_val = lookup_values.at(0);
+            for (auto i = subtable.begin; i <= subtable.end; i++) {
+                if (table_vals.at(subtable.column_indices.at(0)).at(i) == first_val) {
+                    row_index = i;
+                    if (lookup_values.size() <= 1) {
+                        break;
+                    }
+                    auto second_val = lookup_values.at(1);
+                    for (auto j = i; j <= subtable.end; j++) {
+                        if (table_vals.at(subtable.column_indices.at(0)).at(j) == first_val &&
+                            table_vals.at(subtable.column_indices.at(1)).at(j) == second_val) {
+                            row_index = j;
+                        }
+                    }
+                    break;
+                }
+            }
+            if (row_index == -1) {
+                std::cout << "Lookup gates error" << std::endl;
+                std::cout << "Table: " << name << std::endl;
+                std::cout << "Row: " << row << std::endl;
+                std::cout << "lookup(0): " << first_val << std::endl;
+                return false;
+            } else {
+                for (auto i = 0; i < subtable.column_indices.size(); i++) {
+                    auto col = subtable.column_indices.at(i);
+                    auto val = table_vals.at(col).at(row_index);
+                    auto lookup_val = lookup_values.at(i);
+                    if (val != lookup_val) {
+                        std::cout << "Lookup gates error" << std::endl;
+                        std::cout << "Table: " << name << std::endl;
+                        std::cout << "Row: " << row << std::endl;
+                        std::cout << "Index: " << i << std::endl;
+                        std::cout << "Expected: " << lookup_val << std::endl;
+                        std::cout << "Actual: " << val << std::endl;
+                        std::cout << "lookup(0): " << first_val << std::endl;
+                        std::cout << "Note that this error might be wrong if you have more than two inputs for this "
+                                     "lookup table."
+                                  << std::endl;
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        template<typename BlueprintFieldType, typename ArithmetizationParams>
         bool check_lookup_tables(
             circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
             const assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
@@ -49,73 +152,8 @@ namespace nil {
                     if (selector == 1) {
                         // Get the constraints in the gate
                         for (auto &constraint : constraints) {
-                            auto table_id = constraint.table_id;
-                            auto &lookup_input = constraint.lookup_input;
-
-                            // Get the lookup values
-                            std::vector<value_type> lookup_values;
-                            lookup_values.reserve(lookup_input.size());
-                            for (auto &t : lookup_input) {
-                                nil::crypto3::math::term<var> term =
-                                    boost::get<nil::crypto3::math::term<var>>(t.get_expr());
-                                BLUEPRINT_RELEASE_ASSERT(term.get_vars().size() == 1);
-                                var val = term.get_vars()[0];
-                                val.rotation += row;
-                                auto value = var_value(assignment, val);
-                                lookup_values.push_back(value);
-                            }
-
-                            // Get lookup table
-                            std::string name = "";
-                            for (auto el : indices) {
-                                if (el.second == table_id) {
-                                    name = el.first;
-                                    break;
-                                }
-                            }
-                            BLUEPRINT_RELEASE_ASSERT(name != "");
-                            auto index = name.find("/");
-                            BLUEPRINT_RELEASE_ASSERT(index != -1);
-                            auto tab_name = name.substr(0, index);
-                            auto sub_name = name.substr(index + 1);
-
-                            auto &table = lookup_tables.at(tab_name);
-                            auto &table_vals = table->get_table();
-                            auto &subtable = table->subtables.at(sub_name);
-
-                            BLUEPRINT_RELEASE_ASSERT(subtable.column_indices.size() == lookup_values.size());
-
-                            // Compare to the actual table
-                            auto row_index = -1;
-                            auto first_val = lookup_values.at(0);
-                            for (auto i = subtable.begin; i <= subtable.end; i++) {
-                                if (table_vals.at(0).at(i) == first_val) {
-                                    row_index = i;
-                                    break;
-                                }
-                            }
-                            if (row_index == -1) {
-                                std::cout << "Lookup gates error" << std::endl;
-                                std::cout << "Table: " << name << std::endl;
-                                std::cout << "Row: " << row << std::endl;
-                                std::cout << "lookup(0): " << first_val << std::endl;
+                            if (!check_lookup_constraint(bp, assignment, constraint, row)) {
                                 return false;
-                            } else {
-                                for (auto i = 0; i < subtable.column_indices.size(); i++) {
-                                    auto col = subtable.column_indices.at(i);
-                                    auto val = table_vals.at(col).at(row_index);
-                                    auto lookup_val = lookup_values.at(i);
-                                    if (val != lookup_val) {
-                                        std::cout << "Lookup gates error" << std::endl;
-                                        std::cout << "Table: " << name << std::endl;
-                                        std::cout << "Row: " << row << std::endl;
-                                        std::cout << "Index: " << i << std::endl;
-                                        std::cout << "Expected: " << lookup_val << std::endl;
-                                        std::cout << "Actual: " << val << std::endl;
-                                        std::cout << "lookup(0): " << first_val << std::endl;
-                                        return false;
-                                    }
-                                }
                             }
                         }
                     }

--- a/include/nil/blueprint/components/algebra/fixedpoint/type.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/type.hpp
@@ -10,6 +10,8 @@
 #include <nil/crypto3/multiprecision/cpp_bin_float.hpp>
 #include <nil/crypto3/multiprecision/detail/default_ops.hpp>
 
+#include "nil/blueprint/components/cell_position.hpp"
+
 // macro for getting a variable list from a cell position for fixedpoint components
 #define splat(x) x.column(), x.row()
 
@@ -29,31 +31,6 @@ namespace nil {
                 using value_type = typename BlueprintFieldType::value_type;
                 value_type quotient;
                 value_type remainder;
-            };
-
-            /**
-             * Defines the position (column and row indices) of a cell for easier handling thereof in functions.
-             *
-             * Using uint64_t to be on the safe side for any computations as of today.
-             */
-            class CellPosition {
-                int64_t column_;
-                int64_t row_;
-                bool valid_;
-
-            public:
-                CellPosition() : column_(0), row_(0), valid_(false) {
-                }
-                CellPosition(int64_t column, int64_t row) : column_(column), row_(row), valid_(true) {
-                }
-                int64_t column() const {
-                    BLUEPRINT_RELEASE_ASSERT(valid_ && "CellPosition is not defined");
-                    return column_;
-                }
-                int64_t row() const {
-                    BLUEPRINT_RELEASE_ASSERT(valid_ && "CellPosition is not defined");
-                    return row_;
-                }
             };
 
             template<typename BlueprintFieldType>

--- a/include/nil/blueprint/components/cell_position.hpp
+++ b/include/nil/blueprint/components/cell_position.hpp
@@ -1,0 +1,38 @@
+#ifndef CRYPTO3_BLUEPRINT_COMPONENTS_PLONK_CELL_POSITION_HPP
+#define CRYPTO3_BLUEPRINT_COMPONENTS_PLONK_CELL_POSITION_HPP
+
+#include <cstdint>
+#include <nil/blueprint/assert.hpp>
+
+// macro for getting a variable list from a cell position
+#define splat(x) x.column(), x.row()
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+            /**
+             * Defines the position (column and row indices) of a cell for easier handling thereof in components.
+             */
+            class CellPosition {
+                int64_t column_;
+                int64_t row_;
+                bool valid_;
+
+            public:
+                CellPosition() : column_(0), row_(0), valid_(false) {
+                }
+                CellPosition(int64_t column, int64_t row) : column_(column), row_(row), valid_(true) {
+                }
+                int64_t column() const {
+                    BLUEPRINT_RELEASE_ASSERT(valid_ && "CellPosition is not defined");
+                    return column_;
+                }
+                int64_t row() const {
+                    BLUEPRINT_RELEASE_ASSERT(valid_ && "CellPosition is not defined");
+                    return row_;
+                }
+            };
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+#endif    // CRYPTO3_BLUEPRINT_COMPONENTS_PLONK_CELL_POSITION_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -206,6 +206,7 @@ SET(FIXEDPOINT_TESTS_FILES
     "algebra/fixedpoint/plonk/tester"
     "algebra/fixedpoint/plonk/trigonometric"
     "algebra/fixedpoint/plonk/boolean"
+    "algebra/fields/plonk/bitwise"
 )
 
 SET(ALGEBRA_TESTS_FILES

--- a/test/algebra/fields/plonk/bitwise.cpp
+++ b/test/algebra/fields/plonk/bitwise.cpp
@@ -1,0 +1,191 @@
+#define BOOST_TEST_MODULE blueprint_plonk_fields_bitwise_test
+
+// Enable for faster tests
+// #define TEST_WITHOUT_LOOKUP_TABLES
+
+// Enable to see progress on stdout
+// #define STDOUT_TEST_PROGRESS
+
+#include <boost/test/unit_test.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <boost/random/mersenne_twister.hpp>
+
+#include <nil/crypto3/algebra/fields/bls12/scalar_field.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/bls12.hpp>
+#include <nil/crypto3/algebra/curves/vesta.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/vesta.hpp>
+#include <nil/crypto3/algebra/curves/pallas.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/pallas.hpp>
+
+#include <nil/crypto3/hash/keccak.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <boost/random/mersenne_twister.hpp>
+
+#include <nil/blueprint/blueprint/plonk/assignment.hpp>
+#include <nil/blueprint/blueprint/plonk/circuit.hpp>
+
+#include <nil/blueprint/components/algebra/fields/plonk/bitwise_and.hpp>
+#include <nil/blueprint/components/algebra/fields/plonk/bitwise_xor.hpp>
+#include <nil/blueprint/components/algebra/fields/plonk/bitwise_or.hpp>
+
+#include "../../../test_plonk_component.hpp"
+
+using namespace nil;
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+#define macro_component_setup(name)                                                                                    \
+    constexpr std::size_t WitnessColumns = 15;                                                                         \
+    constexpr std::size_t PublicInputColumns = 5;                                                                      \
+    constexpr std::size_t ConstantColumns = 15;                                                                        \
+    constexpr std::size_t SelectorColumns = 30;                                                                        \
+                                                                                                                       \
+    using value_type = typename BlueprintFieldType::value_type;                                                        \
+    using ArithmetizationParams = crypto3::zk::snark::plonk_arithmetization_params<WitnessColumns, PublicInputColumns, \
+                                                                                   ConstantColumns, SelectorColumns>;  \
+    using ArithmetizationType =                                                                                        \
+        crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;                        \
+    using hash_type = nil::crypto3::hashes::keccak_1600<256>;                                                          \
+    constexpr std::size_t Lambda = 40;                                                                                 \
+    using AssignmentType = nil::blueprint::assignment<ArithmetizationType>;                                            \
+                                                                                                                       \
+    using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;                           \
+                                                                                                                       \
+    using component_type = blueprint::components::name<ArithmetizationType, BlueprintFieldType,                        \
+                                                       nil::blueprint::basic_non_native_policy<BlueprintFieldType>>;
+
+#define macro_component_run(readable_name)                                                                      \
+                                                                                                                \
+    typename component_type::input_type instance_input = {var(0, 0, false, var::column_type::public_input),     \
+                                                          var(0, 1, false, var::column_type::public_input)};    \
+                                                                                                                \
+    auto result_check = [expected_res, a, b, m](AssignmentType &assignment,                                     \
+                                                typename component_type::result_type &real_res) {               \
+        auto real_res_ = var_value(assignment, real_res.output);                                                \
+        auto expected = value_type(expected_res);                                                               \
+        if (expected != real_res_) {                                                                            \
+            std::cout << std::endl << "ERROR at " << readable_name << ":" << std::endl;                         \
+            std::cout << "a                : " << a << std::endl;                                               \
+            std::cout << "a (field)        : " << value_type(a) << std::endl;                                   \
+            std::cout << "b                : " << b << std::endl;                                               \
+            std::cout << "b (field)        : " << value_type(b) << std::endl;                                   \
+            std::cout << "expected         : " << expected_res << std::endl;                                    \
+            std::cout << "expected (field) : " << expected << std::endl;                                        \
+            std::cout << "real (field)     : " << real_res_ << std::endl;                                       \
+            std::cout << "m                : " << int(m) << std::endl;                                          \
+            abort();                                                                                            \
+        }                                                                                                       \
+    };                                                                                                          \
+                                                                                                                \
+    std::vector<std::uint32_t> witness_list;                                                                    \
+    witness_list.reserve(WitnessColumns);                                                                       \
+    for (auto i = 0; i < WitnessColumns; i++) {                                                                 \
+        witness_list.push_back(i);                                                                              \
+    }                                                                                                           \
+    std::vector<std::uint32_t> const_list;                                                                      \
+    const_list.reserve(ConstantColumns);                                                                        \
+    for (auto i = 0; i < ConstantColumns; i++) {                                                                \
+        const_list.push_back(i);                                                                                \
+    }                                                                                                           \
+    component_type component_instance(witness_list, const_list, std::array<std::uint32_t, 0>(), m);             \
+    std::vector<typename BlueprintFieldType::value_type> public_input = {value_type(a), value_type(b)};         \
+    nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>( \
+        component_instance, public_input, result_check, instance_input,                                         \
+        crypto3::detail::connectedness_check_type::STRONG, m);
+
+#define macro_stdout_test_progress(readable_name)                                \
+    std::cout << std::endl << "STARTING " << readable_name << ":" << std::endl;  \
+    std::cout << "a                : " << a << std::endl;                        \
+    std::cout << "a (field)        : " << value_type(a) << std::endl;            \
+    std::cout << "b                : " << b << std::endl;                        \
+    std::cout << "b (field)        : " << value_type(b) << std::endl;            \
+    std::cout << "expected         : " << expected_res << std::endl;             \
+    std::cout << "expected (field) : " << value_type(expected_res) << std::endl; \
+    std::cout << "m                : " << int(m) << std::endl;
+
+template<typename BlueprintFieldType, typename IntegerType>
+void test_bitwise_and(IntegerType a, IntegerType b, uint8_t m) {
+    const static char *readable_name = "bitwise AND component";
+    macro_component_setup(bitwise_and);
+    IntegerType expected_res = a & b;
+#ifdef STDOUT_TEST_PROGRESS
+    macro_stdout_test_progress(readable_name);
+#endif    // STDOUT_TEST_PROGRESS
+    macro_component_run(readable_name);
+}
+
+template<typename BlueprintFieldType, typename IntegerType>
+void test_bitwise_xor(IntegerType a, IntegerType b, uint8_t m) {
+    const static char *readable_name = "bitwise XOR component";
+    macro_component_setup(bitwise_xor);
+    IntegerType expected_res = a ^ b;
+#ifdef STDOUT_TEST_PROGRESS
+    macro_stdout_test_progress(readable_name);
+#endif    // STDOUT_TEST_PROGRESS
+    macro_component_run(readable_name);
+}
+
+template<typename BlueprintFieldType, typename IntegerType>
+void test_bitwise_or(IntegerType a, IntegerType b, uint8_t m) {
+    const static char *readable_name = "bitwise OR component";
+    macro_component_setup(bitwise_or);
+    IntegerType expected_res = a | b;
+#ifdef STDOUT_TEST_PROGRESS
+    macro_stdout_test_progress(readable_name);
+#endif    // STDOUT_TEST_PROGRESS
+    macro_component_run(readable_name);
+}
+
+constexpr static const std::size_t random_tests_amount = 10;
+
+template<typename BlueprintFieldType, typename IntegerType>
+void test_bitwise(IntegerType a, IntegerType b, uint8_t m) {
+    test_bitwise_and<BlueprintFieldType, IntegerType>(a, b, m);
+    test_bitwise_xor<BlueprintFieldType, IntegerType>(a, b, m);
+    test_bitwise_or<BlueprintFieldType, IntegerType>(a, b, m);
+}
+
+template<typename BlueprintFieldType, typename IntegerType, typename RngType>
+void test_random(uint8_t m, RngType &rng) {
+    using distribution = boost::random::uniform_int_distribution<IntegerType>;
+    IntegerType max = std::numeric_limits<IntegerType>::max();
+    IntegerType min = std::numeric_limits<IntegerType>::min();
+    distribution dist = distribution(min, max);
+    for (size_t i = 0; i < random_tests_amount; i++) {
+        IntegerType a = dist(rng);
+        IntegerType b = dist(rng);
+        test_bitwise<BlueprintFieldType, IntegerType>(a, b, m);
+    }
+}
+
+template<typename BlueprintFieldType>
+void test_integer_variants() {
+    boost::random::mt19937 rng(0);
+    test_random<BlueprintFieldType, int8_t, boost::random::mt19937>(1, rng);
+    test_random<BlueprintFieldType, int16_t, boost::random::mt19937>(2, rng);
+    test_random<BlueprintFieldType, int32_t, boost::random::mt19937>(4, rng);
+    test_random<BlueprintFieldType, int64_t, boost::random::mt19937>(8, rng);
+    test_random<BlueprintFieldType, uint8_t, boost::random::mt19937>(1, rng);
+    test_random<BlueprintFieldType, uint16_t, boost::random::mt19937>(2, rng);
+    test_random<BlueprintFieldType, uint32_t, boost::random::mt19937>(4, rng);
+    test_random<BlueprintFieldType, uint64_t, boost::random::mt19937>(8, rng);
+}
+
+BOOST_AUTO_TEST_SUITE(blueprint_plonk_test_suite)
+
+BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_bitwise_test_vesta) {
+    using field_type = typename crypto3::algebra::curves::vesta::base_field_type;
+    test_integer_variants<field_type>();
+}
+
+BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_bitwise_test_pallas) {
+    using field_type = typename crypto3::algebra::curves::pallas::base_field_type;
+    test_integer_variants<field_type>();
+}
+
+BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_bitwise_test_bls12) {
+    using field_type = typename crypto3::algebra::fields::bls12_fr<381>;
+    test_integer_variants<field_type>();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/algebra/fixedpoint/plonk/boolean.cpp
+++ b/test/algebra/fixedpoint/plonk/boolean.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE blueprint_plonk_fixedpoint_trigonometric_operations_test
+#define BOOST_TEST_MODULE blueprint_plonk_fixedpoint_boolean_operations_test
 
 // Enable for faster tests
 // #define TEST_WITHOUT_LOOKUP_TABLES


### PR DESCRIPTION
Gadgets use expressions as inputs to lookup tables. Field elements get decomposed into 8-bit limbs and the results of bitwise operations are retrieved from lookup tables.

Inputs: `x, y` 
Outputs: `z`
Parameter: `m`

`m` is the amount of 8-bit limbs (`m` in `[1, 8]`).
`let n = prime - 2^(8m)`, where `prime` is the modulus of the underlying field.
`x` and `y` get decomposed into `m` 8-bit limbs (`x_0, .., x_(m-1)` and `y_0, .., y_(m-1)`) and one sign bit (`s_x`, `s_y`, both in `{0, 1}`) .


$$x = s_x \cdot n + \sum_{i=0}^{m-1}x_i \cdot 2^{8i}$$

$$y = s_y \cdot n + \sum_{i=0}^{m-1}y_i \cdot 2^{8i}$$

$$z = s_z \cdot n + \sum_{i=0}^{m-1}z_i \cdot 2^{8i}$$
