### PR TITLE
feat: Add gadgets for sinh and cosh

### DIFF
--- a/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/hyperbolic.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/lookup_tables/hyperbolic.hpp
@@ -1,0 +1,121 @@
+#ifndef CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_HYPERBOLIC_TABLE_HPP
+#define CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_HYPERBOLIC_TABLE_HPP
+
+#include <string>
+#include <map>
+
+#include <nil/crypto3/zk/snark/arithmetization/plonk/lookup_table_definition.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/tables.hpp>
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+
+            ////////////////////////////////////////////////////////////////////
+            //////// TRIGON 16
+            ////////////////////////////////////////////////////////////////////
+
+            template<typename BlueprintFieldType>
+            class fixedpoint_hyperb_16_table
+                : public nil::crypto3::zk::snark::lookup_table_definition<BlueprintFieldType> {
+
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::lookup_table_definition<BlueprintFieldType>;
+                using fixedpoint_tables = FixedPointTables<BlueprintFieldType>;
+
+            public:
+                static constexpr const char *TABLE_NAME = "fixedpoint_hyperb_16_table";
+                static constexpr const char *SINH_A = "sinh_a";
+                static constexpr const char *SINH_B = "sinh_b";
+                static constexpr const char *COSH_A = "cosh_a";
+                static constexpr const char *COSH_B = "cosh_b";
+                static constexpr const char *FULL_SINH_A = "fixedpoint_hyperb_16_table/sinh_a";
+                static constexpr const char *FULL_SINH_B = "fixedpoint_hyperb_16_table/sinh_b";
+                static constexpr const char *FULL_COSH_A = "fixedpoint_hyperb_16_table/cosh_a";
+                static constexpr const char *FULL_COSH_B = "fixedpoint_hyperb_16_table/cosh_b";
+
+                // TACEO_TODO this hardcoded, indices might be wrong, are they though?..
+                fixedpoint_hyperb_16_table() : lookup_table_definition(TABLE_NAME) {
+                    this->subtables[SINH_A] = {{0, 1}, 0, fixedpoint_tables::SinXLen - 1};
+                    this->subtables[SINH_B] = {{0, 2}, 0, fixedpoint_tables::SinXLen - 1};
+                    this->subtables[COSH_A] = {{0, 3}, 0, fixedpoint_tables::SinXLen - 1};
+                    this->subtables[COSH_B] = {{0, 4}, 0, fixedpoint_tables::SinXLen - 1};
+                }
+
+                virtual void generate() {
+                    BLUEPRINT_RELEASE_ASSERT(fixedpoint_tables::RangeLen == fixedpoint_tables::SinXLen);
+                    auto input = fixedpoint_tables::get_range_table();
+                    auto sinh_a = fixedpoint_tables::get_sinh_a_16();
+                    auto sinh_b = fixedpoint_tables::get_sinh_b_16();
+                    auto cosh_a = fixedpoint_tables::get_cosh_a_16();
+                    auto cosh_b = fixedpoint_tables::get_cosh_b_16();
+                    this->_table = {input, sinh_a, sinh_b, cosh_a, cosh_b};
+                }
+
+                virtual std::size_t get_columns_number() {
+                    return 5;
+                }
+
+                virtual std::size_t get_rows_number() {
+                    return fixedpoint_tables::SinXLen;
+                }
+            };
+
+            ////////////////////////////////////////////////////////////////////
+            //////// TRIGON 32
+            ////////////////////////////////////////////////////////////////////
+
+            template<typename BlueprintFieldType>
+            class fixedpoint_hyperb_32_table
+                : public nil::crypto3::zk::snark::lookup_table_definition<BlueprintFieldType> {
+
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::lookup_table_definition<BlueprintFieldType>;
+                using fixedpoint_tables = FixedPointTables<BlueprintFieldType>;
+
+            public:
+                static constexpr const char *TABLE_NAME = "fixedpoint_hyperb_32_table";
+                static constexpr const char *SINH_A = "sinh_a";
+                static constexpr const char *SINH_B = "sinh_b";
+                static constexpr const char *SINH_C = "sinh_c";
+                static constexpr const char *COSH_A = "cosh_a";
+                static constexpr const char *COSH_B = "cosh_b";
+                static constexpr const char *FULL_SINH_A = "fixedpoint_hyperb_32_table/sinh_a";
+                static constexpr const char *FULL_SINH_B = "fixedpoint_hyperb_32_table/sinh_b";
+                static constexpr const char *FULL_SINH_C = "fixedpoint_hyperb_32_table/sinh_c";
+                static constexpr const char *FULL_COSH_A = "fixedpoint_hyperb_32_table/cosh_a";
+                static constexpr const char *FULL_COSH_B = "fixedpoint_hyperb_32_table/cosh_b";
+
+                // TACEO_TODO this hardcoded, indices might be wrong, are they though?..
+                fixedpoint_hyperb_32_table() : lookup_table_definition(TABLE_NAME) {
+                    this->subtables[SINH_A] = {{0, 1}, 0, fixedpoint_tables::SinXLen - 1};
+                    this->subtables[SINH_B] = {{0, 2}, 0, fixedpoint_tables::SinXLen - 1};
+                    this->subtables[SINH_C] = {{0, 3}, 0, fixedpoint_tables::SinXLen - 1};
+                    this->subtables[COSH_A] = {{0, 4}, 0, fixedpoint_tables::SinXLen - 1};
+                    this->subtables[COSH_B] = {{0, 5}, 0, fixedpoint_tables::SinXLen - 1};
+                }
+
+                virtual void generate() {
+                    BLUEPRINT_RELEASE_ASSERT(fixedpoint_tables::RangeLen == fixedpoint_tables::SinXLen);
+                    auto input = fixedpoint_tables::get_range_table();
+                    auto sinh_a = fixedpoint_tables::get_sinh_a_32();
+                    auto sinh_b = fixedpoint_tables::get_sinh_b_32();
+                    auto sinh_c = fixedpoint_tables::get_sinh_c_32();
+                    auto cosh_a = fixedpoint_tables::get_cosh_a_32();
+                    auto cosh_b = fixedpoint_tables::get_cosh_b_32();
+                    this->_table = {input, sinh_a, sinh_b, sinh_c, cosh_a, cosh_b};
+                }
+
+                virtual std::size_t get_columns_number() {
+                    return 6;
+                }
+
+                virtual std::size_t get_rows_number() {
+                    return fixedpoint_tables::SinXLen;
+                }
+            };
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_HYPERBOLIC_TABLE_HPP

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/cosh.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/cosh.hpp
@@ -1,0 +1,656 @@
+#ifndef CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_COSH_HPP
+#define CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_COSH_HPP
+
+#include <nil/crypto3/zk/snark/arithmetization/plonk/constraint_system.hpp>
+
+#include <nil/blueprint/blueprint/plonk/assignment.hpp>
+#include <nil/blueprint/blueprint/plonk/circuit.hpp>
+#include <nil/blueprint/component.hpp>
+#include <nil/blueprint/manifest.hpp>
+#include <nil/blueprint/basic_non_native_policy.hpp>
+
+#include "nil/blueprint/components/algebra/fixedpoint/type.hpp"
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp"
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/hyperbolic.hpp"
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+
+            // Works by decomposing x into up to three limbs and using the identities sinh(a+b) = sinh(a)cosh(b) +
+            // cosh(a)sinh(b) and cosh(a+b) = cosh(a)cosh(b) + sinh(a)sinh(b) multiple times, followed by one custom
+            // rescale operation. The evaluations of sinh and cosh are retrieved via pre-computed lookup tables.
+            // Large evaluations of sinh and cosh are clipped to the largest and smallest possible values of the current
+            // fixedpoint representation.
+            
+            /**
+             * Component representing a cosh operation with input x and output y, where y = cosh(x).
+             *
+             * The delta of y is the same as the delta of x.
+             *
+             * Input:  x ... field element
+             * Output: y ... cosh(x) (field element)
+             */
+            template<typename ArithmetizationType, typename FieldType, typename NonNativePolicyType>
+            class fix_cosh;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams, typename NonNativePolicyType>
+            class fix_cosh<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                           BlueprintFieldType, NonNativePolicyType>
+                : public plonk_component<BlueprintFieldType, ArithmetizationParams, 0, 0> {
+
+            private:
+                uint8_t m1;    // Pre-comma 16-bit limbs
+                uint8_t m2;    // Post-comma 16-bit limbs
+
+                static uint8_t M(uint8_t m) {
+                    if (m == 0 || m > 2) {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+                    return m;
+                }
+
+            public:
+                struct var_positions {
+                    CellPosition x, y, s_x, x0, s_d, d0, q0, sinh0, cosh0, cosh1;
+                    int64_t start_row;
+                };
+
+                var_positions get_var_pos(const int64_t start_row_index) const {
+
+                    auto m1 = this->m1;
+                    auto m2 = this->m2;
+                    auto m = m1 + m2;
+                    var_positions pos;
+
+                    pos.start_row = start_row_index;
+
+                    if (2 == m2) {
+                        // trace layout (7 + m col(s), 2 row(s))
+                        //
+                        //     |                             witness                             |
+                        //  r\c| 0 |  1  | 2  | .. | 1+m |  2+m  | 3 + m | 4 + m | 5 + m | 6 + m |
+                        // +---+---+-----+----+----+-----+-------+-------+-------+-------+-------+
+                        // | 0 | x | s_x | x0 | .. | x_m |  q_0  |  q_1  |  q_2  |  q_3  |   -   |
+                        // | 1 | y | s_d | d0 | .. | d_m | sinh0 | sinh1 | sinh2 | cosh0 | cosh1 |
+
+                        pos.x = CellPosition(this->W(0), pos.start_row);
+                        pos.s_x = CellPosition(this->W(1), pos.start_row);
+                        pos.x0 = CellPosition(this->W(2 + 0 * m), pos.start_row);    // occupies m cells
+                        pos.q0 = CellPosition(this->W(2 + 1 * m), pos.start_row);    // occupies 4 cells
+
+                        pos.y = CellPosition(this->W(0), pos.start_row + 1);
+                        pos.s_d = CellPosition(this->W(1), pos.start_row + 1);
+                        pos.d0 = CellPosition(this->W(2 + 0 * m), pos.start_row + 1);       // occupies m cells
+                        pos.sinh0 = CellPosition(this->W(2 + 1 * m), pos.start_row + 1);    // occupies 3 cells
+                        pos.cosh0 = CellPosition(this->W(5 + 1 * m), pos.start_row + 1);
+                        pos.cosh1 = CellPosition(this->W(6 + 1 * m), pos.start_row + 1);
+
+                    } else if (1 == m2) {
+                        // trace layout (9 + 2m col(s), 1 row(s))
+                        //
+                        //     |                                       witness                                        |
+                        //  r\c| 0 | 1 |  2  | 3  |..| 2+m  | 3+m | 4+m|..| 3+2m |4+2m| 5+2m  | 6+2m  | 7+2m  | 8+2m  |
+                        // +---+---+---+-----+----+--+------+-----+----+--+------+----+-------+-------+-------+-------+
+                        // | 0 | x | y | s_x | x0 |..| xm-1 | s_d | d0 |..| dm-1 | q0 | sinh0 | sinh1 | cosh0 | cosh1 |
+
+                        pos.x = CellPosition(this->W(0), pos.start_row);
+                        pos.y = CellPosition(this->W(1), pos.start_row);
+                        pos.s_x = CellPosition(this->W(2), pos.start_row);
+                        pos.x0 = CellPosition(this->W(3 + 0 * m), pos.start_row);    // occupies m cells
+                        pos.s_d = CellPosition(this->W(3 + 1 * m), pos.start_row);
+                        pos.d0 = CellPosition(this->W(4 + 1 * m), pos.start_row);    // occupies m cells
+                        pos.q0 = CellPosition(this->W(4 + 2 * m), pos.start_row);
+                        pos.sinh0 = CellPosition(this->W(5 + 2 * m), pos.start_row);    // occupies 2 cells
+                        pos.cosh0 = CellPosition(this->W(7 + 2 * m), pos.start_row);
+                        pos.cosh1 = CellPosition(this->W(8 + 2 * m), pos.start_row);
+                    } else {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+                    return pos;
+                }
+
+            public:
+                uint64_t get_delta() const {
+                    return 1ULL << (16 * this->m2);
+                }
+
+                uint8_t get_m2() const {
+                    return this->m2;
+                }
+
+                uint8_t get_m1() const {
+                    return this->m1;
+                }
+
+                uint8_t get_m() const {
+                    return this->m1 + this->m2;
+                }
+
+                static std::size_t get_witness_columns(uint8_t m1, uint8_t m2) {
+                    return M(m2) == 1 ? 9 + 2 * (M(m1) + m2) : 7 + m1 + m2;
+                }
+
+                using component_type = plonk_component<BlueprintFieldType, ArithmetizationParams, 0, 0>;
+
+                using var = typename component_type::var;
+                using value_type = typename BlueprintFieldType::value_type;
+                using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::lookup_table_definition<BlueprintFieldType>;
+                using range_table = fixedpoint_range_table<BlueprintFieldType>;
+
+                void initialize_assignment(
+                    assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                        &assignment,
+                    const std::uint32_t start_row_index) const {
+                    auto num_cols = this->get_witness_columns(m1, m2);
+                    auto num_rows = this->rows_amount;
+                    for (std::size_t i = 0; i < num_cols; ++i) {
+                        for (std::size_t j = 0; j < num_rows; ++j) {
+                            assignment.witness(this->W(i), start_row_index + j) = value_type::zero();
+                        }
+                    }
+                }
+
+            public:
+                const value_type h;
+                value_type get_h() const {
+                    return h;
+                }
+
+                value_type fixedpoint_max() const {
+                    if (2 == get_m()) {
+                        return value_type(4294967295ULL);    // 2^32 - 1
+                    } else if (3 == get_m()) {
+                        return value_type(281474976710655ULL);    // 2^48 - 1
+                    } else if (4 == get_m()) {
+                        return value_type(18446744073709551615ULL);    // 2^64 - 1
+                    }
+                    BLUEPRINT_RELEASE_ASSERT(false);
+                    return value_type(0);
+                }
+
+            private:
+                static value_type get_h(uint8_t m1, uint8_t m2) {
+                    if (1 == m1) {
+                        return 1 == m2 ? value_type(772243ULL) : value_type(50609756021ULL);
+                    } else if (2 == m1) {
+                        return 1 == m2 ? value_type(1499061ULL) : value_type(98242467570ULL);
+                    }
+                    BLUEPRINT_RELEASE_ASSERT(false);
+                    return value_type(0);
+                }
+
+            public:
+                class gate_manifest_type : public component_gate_manifest {
+                public:
+                    std::uint32_t gates_amount() const override {
+                        return fix_cosh::gates_amount;
+                    }
+                };
+
+                static gate_manifest get_gate_manifest(std::size_t witness_amount, std::size_t lookup_column_amount,
+                                                       uint8_t m1, uint8_t m2 = 0) {
+                    gate_manifest manifest = gate_manifest(gate_manifest_type());
+                    return manifest;
+                }
+
+                static manifest_type get_manifest(uint8_t m1, uint8_t m2) {
+                    manifest_type manifest = manifest_type(
+                        std::shared_ptr<manifest_param>(new manifest_single_value_param(get_witness_columns(m1, m2))),
+                        false);
+                    return manifest;
+                }
+
+                static std::size_t get_rows_amount(std::size_t witness_amount, std::size_t lookup_column_amount,
+                                                   uint8_t m1, uint8_t m2) {
+                    return static_cast<std::size_t>(m2);
+                }
+
+#ifdef TEST_WITHOUT_LOOKUP_TABLES
+                constexpr static const std::size_t gates_amount = 1;
+#else
+                constexpr static const std::size_t gates_amount = 2;
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+                const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, this->m1, this->m2);
+
+                struct input_type {
+                    var x = var(0, 0, false);
+
+                    std::vector<std::reference_wrapper<var>> all_vars() {
+                        return {x};
+                    }
+                };
+
+                struct result_type {
+                    var output = var(0, 0, false);
+                    result_type(const fix_cosh &component, std::uint32_t start_row_index) {
+                        const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                        output = var(splat(var_pos.y), false);
+                    }
+
+                    result_type(const fix_cosh &component, std::size_t start_row_index) {
+                        const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                        output = var(splat(var_pos.y), false);
+                    }
+
+                    std::vector<var> all_vars() const {
+                        return {output};
+                    }
+                };
+
+// Allows disabling lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result = {
+                        std::shared_ptr<lookup_table_definition>(new range_table())};
+
+                    if (m2 == 1) {
+                        auto table = std::shared_ptr<lookup_table_definition>(
+                            new fixedpoint_hyperb_16_table<BlueprintFieldType>());
+                        result.push_back(table);
+                    } else if (m2 == 2) {
+                        auto table = std::shared_ptr<lookup_table_definition>(
+                            new fixedpoint_hyperb_32_table<BlueprintFieldType>());
+                        result.push_back(table);
+                    } else {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
+
+                    if (m2 == 1) {
+                        lookup_tables[fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_SINH_A] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_SINH_B] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_COSH_A] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_COSH_B] =
+                            0;    // REQUIRED_TABLE
+                    } else if (m2 == 2) {
+                        lookup_tables[fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_SINH_A] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_SINH_B] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_SINH_C] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_COSH_A] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_COSH_B] =
+                            0;    // REQUIRED_TABLE
+                    } else {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+
+                    return lookup_tables;
+                }
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+
+                template<typename ContainerType>
+                explicit fix_cosh(ContainerType witness, uint8_t m1, uint8_t m2) :
+                    component_type(witness, {}, {}, get_manifest(m1, m2)), m1(M(m1)), m2(M(m2)), h(get_h(m1, m2)) {};
+
+                template<typename WitnessContainerType, typename ConstantContainerType,
+                         typename PublicInputContainerType>
+                fix_cosh(WitnessContainerType witness, ConstantContainerType constant,
+                         PublicInputContainerType public_input, uint8_t m1, uint8_t m2) :
+                    component_type(witness, constant, public_input, get_manifest(m1, m2)),
+                    m1(M(m1)), m2(M(m2)), h(get_h(m1, m2)) {};
+
+                fix_cosh(std::initializer_list<typename component_type::witness_container_type::value_type> witnesses,
+                         std::initializer_list<typename component_type::constant_container_type::value_type> constants,
+                         std::initializer_list<typename component_type::public_input_container_type::value_type>
+                             public_inputs,
+                         uint8_t m1, uint8_t m2) :
+                    component_type(witnesses, constants, public_inputs, get_manifest(m1, m2)),
+                    m1(M(m1)), m2(M(m2)), h(get_h(m1, m2)) {};
+            };
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            using plonk_fixedpoint_cosh =
+                fix_cosh<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                         BlueprintFieldType, basic_non_native_policy<BlueprintFieldType>>;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::result_type generate_assignments(
+                const plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams> &component,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::input_type
+                    instance_input,
+                const std::uint32_t start_row_index) {
+
+                component.initialize_assignment(assignment, start_row_index);
+
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                using var = typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::var;
+                using value_type = typename BlueprintFieldType::value_type;
+
+                auto m1 = component.get_m1();
+                auto m2 = component.get_m2();
+                auto m = component.get_m();
+
+                auto one = value_type::one();
+                auto zero = value_type::zero();
+                auto delta = value_type(component.get_delta());
+
+                auto x_val = var_value(assignment, instance_input.x);
+                assignment.witness(splat(var_pos.x)) = x_val;
+
+                std::vector<uint16_t> x0_val;
+                value_type s_x_val, s_d_val;
+                bool sign = FixedPointHelper<BlueprintFieldType>::decompose(x_val, x0_val);
+                s_x_val = sign ? -one : one;
+
+                BLUEPRINT_RELEASE_ASSERT(x0_val.size() >= (m2 + 1));
+                assignment.witness(splat(var_pos.s_x)) = s_x_val;
+                for (size_t i = 0; i < m; i++) {
+                    assignment.witness(var_pos.x0.column() + i, var_pos.x0.row()) = x0_val[i];
+                }
+
+                {
+                    auto x_abs = x_val;
+                    FixedPointHelper<BlueprintFieldType>::abs(x_abs);
+                    auto max_val = component.fixedpoint_max();
+                    const auto h_val = component.get_h();
+                    std::vector<uint16_t> d0_val;
+                    bool sign = FixedPointHelper<BlueprintFieldType>::decompose(h_val - x_abs, d0_val);
+                    s_d_val = sign ? one : zero;    // if sign of d == one --> out of range [-h, h].
+                    assignment.witness(splat(var_pos.s_d)) = s_d_val;
+                    BLUEPRINT_RELEASE_ASSERT(d0_val.size() >= m);
+                    for (auto i = 0; i < m; i++) {
+                        assignment.witness(var_pos.d0.column() + i, var_pos.d0.row()) = d0_val[i];
+                    }
+                }
+
+                auto sinh_a_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_sinh_a_16() :
+                                              FixedPointTables<BlueprintFieldType>::get_sinh_a_32();
+                auto sinh_b_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_sinh_b_16() :
+                                              FixedPointTables<BlueprintFieldType>::get_sinh_b_32();
+                auto cosh_a_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_cosh_a_16() :
+                                              FixedPointTables<BlueprintFieldType>::get_cosh_a_32();
+                auto cosh_b_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_cosh_b_16() :
+                                              FixedPointTables<BlueprintFieldType>::get_cosh_b_32();
+                auto sinh_c_table = FixedPointTables<BlueprintFieldType>::get_sinh_c_32();
+
+                // x0 .. smallest limb, x1 .. 2nd smallest limb, x2 .. 3rd smallest limb (2 or 3 limbs in total)
+                // sinh0 holds the looked-up value of the one and only pre-comma limb, so sinh(a) = sinh0 where a is the
+                // largest limb of the input. a = x0_val[m2], ..
+                auto sinh0_val = sinh_a_table[x0_val[m2 - 0]];                     // 0 .. a
+                auto sinh1_val = sinh_b_table[x0_val[m2 - 1]];                     // 1 .. b
+                auto sinh2_val = m2 == 1 ? zero : sinh_c_table[x0_val[m2 - 2]];    // 2 .. c
+                auto cosh0_val = cosh_a_table[x0_val[m2 - 0]];                     // 0 .. a
+                auto cosh1_val = cosh_b_table[x0_val[m2 - 1]];                     // 1 .. b
+                auto cosh2_val = delta;                                            // 2 .. c
+
+                assignment.witness(splat(var_pos.sinh0)) = sinh0_val;
+                assignment.witness(var_pos.sinh0.column() + 1, var_pos.sinh0.row()) = sinh1_val;
+                if (m2 == 2) {
+                    assignment.witness(var_pos.sinh0.column() + 2, var_pos.sinh0.row()) = sinh2_val;
+                }
+                assignment.witness(splat(var_pos.cosh0)) = cosh0_val;
+                assignment.witness(splat(var_pos.cosh1)) = cosh1_val;
+
+                if (s_d_val == one) {
+                    assignment.witness(splat(var_pos.y)) = component.fixedpoint_max();
+                    return typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::result_type(
+                        component, start_row_index);
+                }
+
+                // sinh(-a)    = -sinh(a)
+                // sinh(a+b)   = sinh(a)cosh(b) + cosh(a)sinh(b)
+                // sinh(a+b+c) = sinh(a+b)cosh(c) + cosh(a+b)sinh(c)
+                //            = cosh(c) * (sinh(a)cosh(b) + cosh(a)sinh(b))
+                //            + sinh(c) * (cosh(a)cosh(b) + sinh(a)sinh(b))
+                // sinh(a) .. sinh0, sinh(b) .. sinh1, sinh(c) .. sinh2
+                // cosh(a) .. cosh0, cosh(b) .. cosh1, cosh(c) .. cosh2
+                value_type computation = m2 == 1 ? (cosh0_val * cosh1_val + sinh0_val * sinh1_val) :
+                                                   (cosh2_val * (cosh0_val * cosh1_val + sinh0_val * sinh1_val) +
+                                                    sinh2_val * (sinh0_val * cosh1_val + cosh0_val * sinh1_val));
+
+                auto actual_delta = m2 == 1 ? delta : delta * delta;
+
+                auto tmp = FixedPointHelper<BlueprintFieldType>::round_div_mod(computation, actual_delta);
+                auto y_val = tmp.quotient;
+                auto q_val = tmp.remainder;
+
+                assignment.witness(splat(var_pos.y)) = y_val;
+
+                if (m2 == 1) {
+                    assignment.witness(splat(var_pos.q0)) = q_val;
+                } else {    // m2 == 2
+                    std::vector<uint16_t> q0_val;
+                    bool sign_ = FixedPointHelper<BlueprintFieldType>::decompose(q_val, q0_val);
+                    BLUEPRINT_RELEASE_ASSERT(!sign_);
+                    BLUEPRINT_RELEASE_ASSERT(q0_val.size() >= (4));
+                    for (size_t i = 0; i < 4; i++) {
+                        assignment.witness(var_pos.q0.column() + i, var_pos.q0.row()) = q0_val[i];
+                    }
+                }
+
+                return typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::vector<crypto3::zk::snark::plonk_constraint<BlueprintFieldType>> get_constraints(
+                const plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+
+                using var = typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::var;
+                auto m1 = component.get_m1();
+                auto m2 = component.get_m2();
+                auto m = component.get_m();
+
+                auto delta = typename BlueprintFieldType::value_type(component.get_delta());
+                auto h = component.get_h();
+                auto max = component.fixedpoint_max();
+                auto x = var(splat(var_pos.x));
+                auto s_x = var(splat(var_pos.s_x));
+                auto s_d = var(splat(var_pos.s_d));
+                auto x0 = nil::crypto3::math::expression(var(splat(var_pos.x0)));
+                auto d = nil::crypto3::math::expression(var(splat(var_pos.d0)));
+
+                // decomposition of x
+                for (size_t i = 1; i < m; i++) {
+                    x0 += var(var_pos.x0.column() + i, var_pos.x0.row()) * (1ULL << (16 * i));
+                    d += var(var_pos.d0.column() + i, var_pos.d0.row()) * (1ULL << (16 * i));
+                }
+
+                // decomposition constraints for x, d
+                auto constraint_1 = x - s_x * x0;
+                auto constraint_2 = (h - x0) + s_d * d - (1 - s_d) * d;
+
+                // sign of x and d
+                auto constraint_3 = (s_x - 1) * (s_x + 1);
+                auto constraint_4 = s_d * (1 - s_d);
+
+                auto y = var(splat(var_pos.y));
+                auto sinh0 = var(splat(var_pos.sinh0));                               // 0 .. a
+                auto sinh1 = var(var_pos.sinh0.column() + 1, var_pos.sinh0.row());    // 1 .. b
+                auto cosh0 = var(splat(var_pos.cosh0));                               // 0 .. a
+                auto cosh1 = var(splat(var_pos.cosh1));                               // 1 .. b
+                auto sinh2 = var(var_pos.sinh0.column() + 2, var_pos.sinh0.row());    // 2 .. c
+                auto cosh2 = delta;                                                   // 2 .. c
+                auto q = nil::crypto3::math::expression(var(splat(var_pos.q0)));
+                for (size_t i = 1; i < m2 * m2; i++) {
+                    q += var(var_pos.q0.column() + i, var_pos.q0.row()) * (1ULL << (16 * i));
+                }
+
+                // sinh(a) .. sinh0, sinh(b) .. sinh1, sinh(c) .. sinh2
+                // cosh(a) .. cosh0, cosh(b) .. cosh1, cosh(c) .. cosh2
+                auto computation =
+                    m2 == 1 ? (cosh0 * cosh1 + sinh0 * sinh1) :
+                              (cosh2 * (cosh0 * cosh1 + sinh0 * sinh1) + sinh2 * (sinh0 * cosh1 + cosh0 * sinh1));
+                auto actual_delta = m2 == 1 ? delta : delta * delta;
+
+                // "custom" rescale
+                auto constraint_5 = (1 - s_d) * (2 * (computation - y * actual_delta - q) + actual_delta);
+                auto constraint_6 = s_d * (y - max);
+
+                return {constraint_1, constraint_2, constraint_3, constraint_4, constraint_5, constraint_6};
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_gates(
+                const plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+
+                auto constraints = get_constraints(component, bp, assignment, instance_input);
+                return bp.add_gate(constraints);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            void generate_copy_constraints(
+                const plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input,
+                const std::size_t start_row_index) {
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                using var = typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::var;
+
+                auto x = var(splat(var_pos.x), false);
+                bp.add_copy_constraint({instance_input.x, x});
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m2 = component.get_m2();
+
+                const auto &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+                using range_table =
+                    typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::range_table;
+
+                auto range_table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
+                auto sinh_a_table_id =
+                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_SINH_A) :
+                              lookup_tables_indices.at(fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_SINH_A);
+                auto sinh_b_table_id =
+                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_SINH_B) :
+                              lookup_tables_indices.at(fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_SINH_B);
+                auto cosh_a_table_id =
+                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_COSH_A) :
+                              lookup_tables_indices.at(fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_COSH_A);
+                auto cosh_b_table_id =
+                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_COSH_B) :
+                              lookup_tables_indices.at(fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_COSH_B);
+
+                std::vector<constraint_type> constraints;
+
+                // lookup decomposition of q
+                for (size_t i = 0; i < m2 * m2; i++) {
+                    constraint_type constraint;
+                    constraint.table_id = range_table_id;
+                    auto qi = var(var_pos.q0.column() + i, var_pos.q0.row());
+                    constraint.lookup_input = {qi};
+                    constraints.push_back(constraint);
+                }
+
+                // lookup sinh, cosh
+                // x0 .. smallest limb, x1 .. 2nd smallest limb, x2 .. 3rd smallest limb (2 or 3 limbs in total)
+                // sinh0 holds the looked-up value of the one and only pre-comma limb, so sinh(a) = sinh0 where a is the
+                // largest limb of the input. a = x0_val[m2], ..
+                auto x0 = var(var_pos.x0.column() + m2 - 0, var_pos.x0.row());
+                auto x1 = var(var_pos.x0.column() + m2 - 1, var_pos.x0.row());
+                auto x2 = var(var_pos.x0.column() + m2 - 2, var_pos.x0.row());    // invalid if m2 == 1
+                auto sinh0 = var(var_pos.sinh0.column() + 0, var_pos.sinh0.row());
+                auto sinh1 = var(var_pos.sinh0.column() + 1, var_pos.sinh0.row());
+                auto sinh2 = var(var_pos.sinh0.column() + 2, var_pos.sinh0.row());    // invalid if m2 == 1
+                {
+                    constraint_type constraint;
+                    constraint.table_id = sinh_a_table_id;
+                    constraint.lookup_input = {x0, sinh0};
+                    constraints.push_back(constraint);
+                }
+                {
+                    constraint_type constraint;
+                    constraint.table_id = cosh_a_table_id;
+                    constraint.lookup_input = {x0, var(splat(var_pos.cosh0))};
+                    constraints.push_back(constraint);
+                }
+                {
+                    constraint_type constraint;
+                    constraint.table_id = sinh_b_table_id;
+                    constraint.lookup_input = {x1, sinh1};
+                    constraints.push_back(constraint);
+                }
+                {
+                    constraint_type constraint;
+                    constraint.table_id = cosh_b_table_id;
+                    constraint.lookup_input = {x1, var(splat(var_pos.cosh1))};
+                    constraints.push_back(constraint);
+                }
+                if (m2 == 2) {
+                    constraint_type constraint;
+                    auto sinh_c_table_id =
+                        lookup_tables_indices.at(fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_SINH_C);
+                    constraint.table_id = sinh_c_table_id;
+                    constraint.lookup_input = {x2, sinh2};
+                    constraints.push_back(constraint);
+                }
+
+                return bp.add_lookup_gate(constraints);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::result_type generate_circuit(
+                const plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input,
+                const std::size_t start_row_index) {
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+
+                std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
+
+                assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
+
+// Allows disabling lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, start_row_index + component.rows_amount - 1);
+#endif
+                generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
+
+                return typename plonk_fixedpoint_cosh<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_COSH_HPP

--- a/include/nil/blueprint/components/algebra/fixedpoint/plonk/sinh.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/plonk/sinh.hpp
@@ -1,0 +1,657 @@
+#ifndef CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_SINH_HPP
+#define CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_SINH_HPP
+
+#include <nil/crypto3/zk/snark/arithmetization/plonk/constraint_system.hpp>
+
+#include <nil/blueprint/blueprint/plonk/assignment.hpp>
+#include <nil/blueprint/blueprint/plonk/circuit.hpp>
+#include <nil/blueprint/component.hpp>
+#include <nil/blueprint/manifest.hpp>
+#include <nil/blueprint/basic_non_native_policy.hpp>
+
+#include "nil/blueprint/components/algebra/fixedpoint/type.hpp"
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/range.hpp"
+#include "nil/blueprint/components/algebra/fixedpoint/lookup_tables/hyperbolic.hpp"
+
+namespace nil {
+    namespace blueprint {
+        namespace components {
+
+            // Works by decomposing x into up to three limbs and using the identities sinh(a+b) = sinh(a)cosh(b) +
+            // cosh(a)sinh(b) and cosh(a+b) = cosh(a)cosh(b) + sinh(a)sinh(b) multiple times, followed by one custom
+            // rescale operation. The evaluations of sinh and cosh are retrieved via pre-computed lookup tables.
+            // Large evaluations of sinh and cosh are clipped to the largest and smallest possible values of the current
+            // fixedpoint representation.
+
+            /**
+             * Component representing a sinh operation with input x and output y, where y = sinh(x).
+             *
+             * The delta of y is the same as the delta of x.
+             *
+             * Input:  x ... field element
+             * Output: y ... sinh(x) (field element)
+             */
+            template<typename ArithmetizationType, typename FieldType, typename NonNativePolicyType>
+            class fix_sinh;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams, typename NonNativePolicyType>
+            class fix_sinh<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                           BlueprintFieldType, NonNativePolicyType>
+                : public plonk_component<BlueprintFieldType, ArithmetizationParams, 0, 0> {
+
+            private:
+                uint8_t m1;    // Pre-comma 16-bit limbs
+                uint8_t m2;    // Post-comma 16-bit limbs
+
+                static uint8_t M(uint8_t m) {
+                    if (m == 0 || m > 2) {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+                    return m;
+                }
+
+            public:
+                struct var_positions {
+                    CellPosition x, y, s_x, x0, s_d, d0, q0, sinh0, cosh0, cosh1;
+                    int64_t start_row;
+                };
+
+                var_positions get_var_pos(const int64_t start_row_index) const {
+
+                    auto m1 = this->m1;
+                    auto m2 = this->m2;
+                    auto m = m1 + m2;
+                    var_positions pos;
+
+                    pos.start_row = start_row_index;
+
+                    if (2 == m2) {
+                        // trace layout (7 + m col(s), 2 row(s))
+                        //
+                        //     |                             witness                             |
+                        //  r\c| 0 |  1  | 2  | .. | 1+m |  2+m  | 3 + m | 4 + m | 5 + m | 6 + m |
+                        // +---+---+-----+----+----+-----+-------+-------+-------+-------+-------+
+                        // | 0 | x | s_x | x0 | .. | x_m |  q_0  |  q_1  |  q_2  |  q_3  |   -   |
+                        // | 1 | y | s_d | d0 | .. | d_m | sinh0 | sinh1 | sinh2 | cosh0 | cosh1 |
+
+                        pos.x = CellPosition(this->W(0), pos.start_row);
+                        pos.s_x = CellPosition(this->W(1), pos.start_row);
+                        pos.x0 = CellPosition(this->W(2 + 0 * m), pos.start_row);    // occupies m cells
+                        pos.q0 = CellPosition(this->W(2 + 1 * m), pos.start_row);    // occupies 4 cells
+
+                        pos.y = CellPosition(this->W(0), pos.start_row + 1);
+                        pos.s_d = CellPosition(this->W(1), pos.start_row + 1);
+                        pos.d0 = CellPosition(this->W(2 + 0 * m), pos.start_row + 1);       // occupies m cells
+                        pos.sinh0 = CellPosition(this->W(2 + 1 * m), pos.start_row + 1);    // occupies 3 cells
+                        pos.cosh0 = CellPosition(this->W(5 + 1 * m), pos.start_row + 1);
+                        pos.cosh1 = CellPosition(this->W(6 + 1 * m), pos.start_row + 1);
+
+                    } else if (1 == m2) {
+                        // trace layout (9 + 2m col(s), 1 row(s))
+                        //
+                        //     |                                       witness                                        |
+                        //  r\c| 0 | 1 |  2  | 3  |..| 2+m  | 3+m | 4+m|..| 3+2m |4+2m| 5+2m  | 6+2m  | 7+2m  | 8+2m  |
+                        // +---+---+---+-----+----+--+------+-----+----+--+------+----+-------+-------+-------+-------+
+                        // | 0 | x | y | s_x | x0 |..| xm-1 | s_d | d0 |..| dm-1 | q0 | sinh0 | sinh1 | cosh0 | cosh1 |
+
+                        pos.x = CellPosition(this->W(0), pos.start_row);
+                        pos.y = CellPosition(this->W(1), pos.start_row);
+                        pos.s_x = CellPosition(this->W(2), pos.start_row);
+                        pos.x0 = CellPosition(this->W(3 + 0 * m), pos.start_row);    // occupies m cells
+                        pos.s_d = CellPosition(this->W(3 + 1 * m), pos.start_row);
+                        pos.d0 = CellPosition(this->W(4 + 1 * m), pos.start_row);    // occupies m cells
+                        pos.q0 = CellPosition(this->W(4 + 2 * m), pos.start_row);
+                        pos.sinh0 = CellPosition(this->W(5 + 2 * m), pos.start_row);    // occupies 2 cells
+                        pos.cosh0 = CellPosition(this->W(7 + 2 * m), pos.start_row);
+                        pos.cosh1 = CellPosition(this->W(8 + 2 * m), pos.start_row);
+                    } else {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+                    return pos;
+                }
+
+            public:
+                uint64_t get_delta() const {
+                    return 1ULL << (16 * this->m2);
+                }
+
+                uint8_t get_m2() const {
+                    return this->m2;
+                }
+
+                uint8_t get_m1() const {
+                    return this->m1;
+                }
+
+                uint8_t get_m() const {
+                    return this->m1 + this->m2;
+                }
+
+                static std::size_t get_witness_columns(uint8_t m1, uint8_t m2) {
+                    return M(m2) == 1 ? 9 + 2 * (M(m1) + m2) : 7 + m1 + m2;
+                }
+
+                using component_type = plonk_component<BlueprintFieldType, ArithmetizationParams, 0, 0>;
+
+                using var = typename component_type::var;
+                using value_type = typename BlueprintFieldType::value_type;
+                using manifest_type = plonk_component_manifest;
+                using lookup_table_definition =
+                    typename nil::crypto3::zk::snark::lookup_table_definition<BlueprintFieldType>;
+                using range_table = fixedpoint_range_table<BlueprintFieldType>;
+
+                void initialize_assignment(
+                    assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                        &assignment,
+                    const std::uint32_t start_row_index) const {
+                    auto num_cols = this->get_witness_columns(m1, m2);
+                    auto num_rows = this->rows_amount;
+                    for (std::size_t i = 0; i < num_cols; ++i) {
+                        for (std::size_t j = 0; j < num_rows; ++j) {
+                            assignment.witness(this->W(i), start_row_index + j) = value_type::zero();
+                        }
+                    }
+                }
+
+            public:
+                const value_type h;
+                value_type get_h() const {
+                    return h;
+                }
+
+                value_type fixedpoint_max() const {
+                    if (2 == get_m()) {
+                        return value_type(4294967295ULL);    // 2^32 - 1
+                    } else if (3 == get_m()) {
+                        return value_type(281474976710655ULL);    // 2^48 - 1
+                    } else if (4 == get_m()) {
+                        return value_type(18446744073709551615ULL);    // 2^64 - 1
+                    }
+                    BLUEPRINT_RELEASE_ASSERT(false);
+                    return value_type(0);
+                }
+
+            private:
+                static value_type get_h(uint8_t m1, uint8_t m2) {
+                    if (1 == m1) {
+                        return 1 == m2 ? value_type(772243ULL) : value_type(50609756021ULL);
+                    } else if (2 == m1) {
+                        return 1 == m2 ? value_type(1499061ULL) : value_type(98242467570ULL);
+                    }
+                    BLUEPRINT_RELEASE_ASSERT(false);
+                    return value_type(0);
+                }
+
+            public:
+                class gate_manifest_type : public component_gate_manifest {
+                public:
+                    std::uint32_t gates_amount() const override {
+                        return fix_sinh::gates_amount;
+                    }
+                };
+
+                static gate_manifest get_gate_manifest(std::size_t witness_amount, std::size_t lookup_column_amount,
+                                                       uint8_t m1, uint8_t m2 = 0) {
+                    gate_manifest manifest = gate_manifest(gate_manifest_type());
+                    return manifest;
+                }
+
+                static manifest_type get_manifest(uint8_t m1, uint8_t m2) {
+                    manifest_type manifest = manifest_type(
+                        std::shared_ptr<manifest_param>(new manifest_single_value_param(get_witness_columns(m1, m2))),
+                        false);
+                    return manifest;
+                }
+
+                static std::size_t get_rows_amount(std::size_t witness_amount, std::size_t lookup_column_amount,
+                                                   uint8_t m1, uint8_t m2) {
+                    return static_cast<std::size_t>(m2);
+                }
+
+#ifdef TEST_WITHOUT_LOOKUP_TABLES
+                constexpr static const std::size_t gates_amount = 1;
+#else
+                constexpr static const std::size_t gates_amount = 2;
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+                const std::size_t rows_amount = get_rows_amount(this->witness_amount(), 0, this->m1, this->m2);
+
+                struct input_type {
+                    var x = var(0, 0, false);
+
+                    std::vector<std::reference_wrapper<var>> all_vars() {
+                        return {x};
+                    }
+                };
+
+                struct result_type {
+                    var output = var(0, 0, false);
+                    result_type(const fix_sinh &component, std::uint32_t start_row_index) {
+                        const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                        output = var(splat(var_pos.y), false);
+                    }
+
+                    result_type(const fix_sinh &component, std::size_t start_row_index) {
+                        const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                        output = var(splat(var_pos.y), false);
+                    }
+
+                    std::vector<var> all_vars() const {
+                        return {output};
+                    }
+                };
+
+// Allows disabling lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::vector<std::shared_ptr<lookup_table_definition>> component_custom_lookup_tables() {
+                    std::vector<std::shared_ptr<lookup_table_definition>> result = {
+                        std::shared_ptr<lookup_table_definition>(new range_table())};
+
+                    if (m2 == 1) {
+                        auto table = std::shared_ptr<lookup_table_definition>(
+                            new fixedpoint_hyperb_16_table<BlueprintFieldType>());
+                        result.push_back(table);
+                    } else if (m2 == 2) {
+                        auto table = std::shared_ptr<lookup_table_definition>(
+                            new fixedpoint_hyperb_32_table<BlueprintFieldType>());
+                        result.push_back(table);
+                    } else {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+
+                    return result;
+                }
+
+                std::map<std::string, std::size_t> component_lookup_tables() {
+                    std::map<std::string, std::size_t> lookup_tables;
+                    lookup_tables[range_table::FULL_TABLE_NAME] = 0;    // REQUIRED_TABLE
+
+                    if (m2 == 1) {
+                        lookup_tables[fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_SINH_A] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_SINH_B] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_COSH_A] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_COSH_B] =
+                            0;    // REQUIRED_TABLE
+                    } else if (m2 == 2) {
+                        lookup_tables[fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_SINH_A] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_SINH_B] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_SINH_C] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_COSH_A] =
+                            0;    // REQUIRED_TABLE
+                        lookup_tables[fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_COSH_B] =
+                            0;    // REQUIRED_TABLE
+                    } else {
+                        BLUEPRINT_RELEASE_ASSERT(false);
+                    }
+
+                    return lookup_tables;
+                }
+#endif    // TEST_WITHOUT_LOOKUP_TABLES
+
+                template<typename ContainerType>
+                explicit fix_sinh(ContainerType witness, uint8_t m1, uint8_t m2) :
+                    component_type(witness, {}, {}, get_manifest(m1, m2)), m1(M(m1)), m2(M(m2)), h(get_h(m1, m2)) {};
+
+                template<typename WitnessContainerType, typename ConstantContainerType,
+                         typename PublicInputContainerType>
+                fix_sinh(WitnessContainerType witness, ConstantContainerType constant,
+                         PublicInputContainerType public_input, uint8_t m1, uint8_t m2) :
+                    component_type(witness, constant, public_input, get_manifest(m1, m2)),
+                    m1(M(m1)), m2(M(m2)), h(get_h(m1, m2)) {};
+
+                fix_sinh(std::initializer_list<typename component_type::witness_container_type::value_type> witnesses,
+                         std::initializer_list<typename component_type::constant_container_type::value_type> constants,
+                         std::initializer_list<typename component_type::public_input_container_type::value_type>
+                             public_inputs,
+                         uint8_t m1, uint8_t m2) :
+                    component_type(witnesses, constants, public_inputs, get_manifest(m1, m2)),
+                    m1(M(m1)), m2(M(m2)), h(get_h(m1, m2)) {};
+            };
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            using plonk_fixedpoint_sinh =
+                fix_sinh<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
+                         BlueprintFieldType, basic_non_native_policy<BlueprintFieldType>>;
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::result_type generate_assignments(
+                const plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams> &component,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::input_type
+                    instance_input,
+                const std::uint32_t start_row_index) {
+
+                component.initialize_assignment(assignment, start_row_index);
+
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                using var = typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::var;
+                using value_type = typename BlueprintFieldType::value_type;
+
+                auto m1 = component.get_m1();
+                auto m2 = component.get_m2();
+                auto m = component.get_m();
+
+                auto one = value_type::one();
+                auto zero = value_type::zero();
+                auto delta = value_type(component.get_delta());
+
+                auto x_val = var_value(assignment, instance_input.x);
+                assignment.witness(splat(var_pos.x)) = x_val;
+
+                std::vector<uint16_t> x0_val;
+                value_type s_x_val, s_d_val;
+                bool sign = FixedPointHelper<BlueprintFieldType>::decompose(x_val, x0_val);
+                s_x_val = sign ? -one : one;
+
+                BLUEPRINT_RELEASE_ASSERT(x0_val.size() >= (m2 + 1));
+                assignment.witness(splat(var_pos.s_x)) = s_x_val;
+                for (size_t i = 0; i < m; i++) {
+                    assignment.witness(var_pos.x0.column() + i, var_pos.x0.row()) = x0_val[i];
+                }
+
+                {
+                    auto x_abs = x_val;
+                    FixedPointHelper<BlueprintFieldType>::abs(x_abs);
+                    auto max_val = component.fixedpoint_max();
+                    const auto h_val = component.get_h();
+                    std::vector<uint16_t> d0_val;
+                    bool sign = FixedPointHelper<BlueprintFieldType>::decompose(h_val - x_abs, d0_val);
+                    s_d_val = sign ? one : zero;    // if sign of d == one --> out of range [-h, h].
+                    assignment.witness(splat(var_pos.s_d)) = s_d_val;
+                    BLUEPRINT_RELEASE_ASSERT(d0_val.size() >= m);
+                    for (auto i = 0; i < m; i++) {
+                        assignment.witness(var_pos.d0.column() + i, var_pos.d0.row()) = d0_val[i];
+                    }
+                }
+
+                auto sinh_a_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_sinh_a_16() :
+                                              FixedPointTables<BlueprintFieldType>::get_sinh_a_32();
+                auto sinh_b_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_sinh_b_16() :
+                                              FixedPointTables<BlueprintFieldType>::get_sinh_b_32();
+                auto cosh_a_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_cosh_a_16() :
+                                              FixedPointTables<BlueprintFieldType>::get_cosh_a_32();
+                auto cosh_b_table = m2 == 1 ? FixedPointTables<BlueprintFieldType>::get_cosh_b_16() :
+                                              FixedPointTables<BlueprintFieldType>::get_cosh_b_32();
+                auto sinh_c_table = FixedPointTables<BlueprintFieldType>::get_sinh_c_32();
+
+                // x0 .. smallest limb, x1 .. 2nd smallest limb, x2 .. 3rd smallest limb (2 or 3 limbs in total)
+                // sinh0 holds the looked-up value of the one and only pre-comma limb, so sinh(a) = sinh0 where a is the
+                // largest limb of the input. a = x0_val[m2], ..
+                auto sinh0_val = sinh_a_table[x0_val[m2 - 0]];                     // 0 .. a
+                auto sinh1_val = sinh_b_table[x0_val[m2 - 1]];                     // 1 .. b
+                auto sinh2_val = m2 == 1 ? zero : sinh_c_table[x0_val[m2 - 2]];    // 2 .. c
+                auto cosh0_val = cosh_a_table[x0_val[m2 - 0]];                     // 0 .. a
+                auto cosh1_val = cosh_b_table[x0_val[m2 - 1]];                     // 1 .. b
+                auto cosh2_val = delta;                                            // 2 .. c
+
+                assignment.witness(splat(var_pos.sinh0)) = sinh0_val;
+                assignment.witness(var_pos.sinh0.column() + 1, var_pos.sinh0.row()) = sinh1_val;
+                if (m2 == 2) {
+                    assignment.witness(var_pos.sinh0.column() + 2, var_pos.sinh0.row()) = sinh2_val;
+                }
+                assignment.witness(splat(var_pos.cosh0)) = cosh0_val;
+                assignment.witness(splat(var_pos.cosh1)) = cosh1_val;
+
+                if (s_d_val == one) {
+                    assignment.witness(splat(var_pos.y)) = s_x_val * component.fixedpoint_max();
+                    return typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::result_type(
+                        component, start_row_index);
+                }
+
+                // sinh(-a)    = -sinh(a)
+                // sinh(a+b)   = sinh(a)cosh(b) + cosh(a)sinh(b)
+                // sinh(a+b+c) = sinh(a+b)cosh(c) + cosh(a+b)sinh(c)
+                //            = cosh(c) * (sinh(a)cosh(b) + cosh(a)sinh(b))
+                //            + sinh(c) * (cosh(a)cosh(b) + sinh(a)sinh(b))
+                // sinh(a) .. sinh0, sinh(b) .. sinh1, sinh(c) .. sinh2
+                // cosh(a) .. cosh0, cosh(b) .. cosh1, cosh(c) .. cosh2
+                value_type computation = m2 == 1 ?
+                                             s_x_val * (sinh0_val * cosh1_val + cosh0_val * sinh1_val) :
+                                             s_x_val * (cosh2_val * (sinh0_val * cosh1_val + cosh0_val * sinh1_val) +
+                                                        sinh2_val * (cosh0_val * cosh1_val + sinh0_val * sinh1_val));
+
+                auto actual_delta = m2 == 1 ? delta : delta * delta;
+
+                auto tmp = FixedPointHelper<BlueprintFieldType>::round_div_mod(computation, actual_delta);
+                auto y_val = tmp.quotient;
+                auto q_val = tmp.remainder;
+
+                assignment.witness(splat(var_pos.y)) = y_val;
+
+                if (m2 == 1) {
+                    assignment.witness(splat(var_pos.q0)) = q_val;
+                } else {    // m2 == 2
+                    std::vector<uint16_t> q0_val;
+                    bool sign_ = FixedPointHelper<BlueprintFieldType>::decompose(q_val, q0_val);
+                    BLUEPRINT_RELEASE_ASSERT(!sign_);
+                    BLUEPRINT_RELEASE_ASSERT(q0_val.size() >= (4));
+                    for (size_t i = 0; i < 4; i++) {
+                        assignment.witness(var_pos.q0.column() + i, var_pos.q0.row()) = q0_val[i];
+                    }
+                }
+
+                return typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::vector<crypto3::zk::snark::plonk_constraint<BlueprintFieldType>> get_constraints(
+                const plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+
+                using var = typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::var;
+                auto m1 = component.get_m1();
+                auto m2 = component.get_m2();
+                auto m = component.get_m();
+
+                auto delta = typename BlueprintFieldType::value_type(component.get_delta());
+                auto h = component.get_h();
+                auto max = component.fixedpoint_max();
+                auto x = var(splat(var_pos.x));
+                auto s_x = var(splat(var_pos.s_x));
+                auto s_d = var(splat(var_pos.s_d));
+                auto x0 = nil::crypto3::math::expression(var(splat(var_pos.x0)));
+                auto d = nil::crypto3::math::expression(var(splat(var_pos.d0)));
+
+                // decomposition of x
+                for (size_t i = 1; i < m; i++) {
+                    x0 += var(var_pos.x0.column() + i, var_pos.x0.row()) * (1ULL << (16 * i));
+                    d += var(var_pos.d0.column() + i, var_pos.d0.row()) * (1ULL << (16 * i));
+                }
+
+                // decomposition constraints for x, d
+                auto constraint_1 = x - s_x * x0;
+                auto constraint_2 = (h - x0) + s_d * d - (1 - s_d) * d;
+
+                // sign of x and d
+                auto constraint_3 = (s_x - 1) * (s_x + 1);
+                auto constraint_4 = s_d * (1 - s_d);
+
+                auto y = var(splat(var_pos.y));
+                auto sinh0 = var(splat(var_pos.sinh0));                               // 0 .. a
+                auto sinh1 = var(var_pos.sinh0.column() + 1, var_pos.sinh0.row());    // 1 .. b
+                auto cosh0 = var(splat(var_pos.cosh0));                               // 0 .. a
+                auto cosh1 = var(splat(var_pos.cosh1));                               // 1 .. b
+                auto sinh2 = var(var_pos.sinh0.column() + 2, var_pos.sinh0.row());    // 2 .. c
+                auto cosh2 = delta;                                                   // 2 .. c
+                auto q = nil::crypto3::math::expression(var(splat(var_pos.q0)));
+                for (size_t i = 1; i < m2 * m2; i++) {
+                    q += var(var_pos.q0.column() + i, var_pos.q0.row()) * (1ULL << (16 * i));
+                }
+
+                // sinh(a) .. sinh0, sinh(b) .. sinh1, sinh(c) .. sinh2
+                // cosh(a) .. cosh0, cosh(b) .. cosh1, cosh(c) .. cosh2
+                auto computation =
+                    m2 == 1 ? s_x * (sinh0 * cosh1 + cosh0 * sinh1) :
+                              s_x * (cosh2 * (sinh0 * cosh1 + cosh0 * sinh1) + sinh2 * (cosh0 * cosh1 + sinh0 * sinh1));
+                auto actual_delta = m2 == 1 ? delta : delta * delta;
+
+                // "custom" rescale
+                auto constraint_5 = (1 - s_d) * (2 * (computation - y * actual_delta - q) + actual_delta);
+                auto constraint_6 = s_d * (y - s_x * max);
+
+                return {constraint_1, constraint_2, constraint_3, constraint_4, constraint_5, constraint_6};
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_gates(
+                const plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+
+                auto constraints = get_constraints(component, bp, assignment, instance_input);
+                return bp.add_gate(constraints);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            void generate_copy_constraints(
+                const plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input,
+                const std::size_t start_row_index) {
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+                using var = typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::var;
+
+                auto x = var(splat(var_pos.x), false);
+                bp.add_copy_constraint({instance_input.x, x});
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            std::size_t generate_lookup_gates(
+                const plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input) {
+                const int64_t start_row_index = 1 - static_cast<int64_t>(component.rows_amount);
+                const auto var_pos = component.get_var_pos(start_row_index);
+                auto m2 = component.get_m2();
+
+                const auto &lookup_tables_indices = bp.get_reserved_indices();
+
+                using var = typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::var;
+                using constraint_type = typename crypto3::zk::snark::plonk_lookup_constraint<BlueprintFieldType>;
+                using range_table =
+                    typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::range_table;
+
+                auto range_table_id = lookup_tables_indices.at(range_table::FULL_TABLE_NAME);
+                auto sinh_a_table_id =
+                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_SINH_A) :
+                              lookup_tables_indices.at(fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_SINH_A);
+                auto sinh_b_table_id =
+                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_SINH_B) :
+                              lookup_tables_indices.at(fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_SINH_B);
+                auto cosh_a_table_id =
+                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_COSH_A) :
+                              lookup_tables_indices.at(fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_COSH_A);
+                auto cosh_b_table_id =
+                    m2 == 1 ? lookup_tables_indices.at(fixedpoint_hyperb_16_table<BlueprintFieldType>::FULL_COSH_B) :
+                              lookup_tables_indices.at(fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_COSH_B);
+
+                std::vector<constraint_type> constraints;
+
+                // lookup decomposition of q
+                for (size_t i = 0; i < m2 * m2; i++) {
+                    constraint_type constraint;
+                    constraint.table_id = range_table_id;
+                    auto qi = var(var_pos.q0.column() + i, var_pos.q0.row());
+                    constraint.lookup_input = {qi};
+                    constraints.push_back(constraint);
+                }
+
+                // lookup sinh, cosh
+                // x0 .. smallest limb, x1 .. 2nd smallest limb, x2 .. 3rd smallest limb (2 or 3 limbs in total)
+                // sinh0 holds the looked-up value of the one and only pre-comma limb, so sinh(a) = sinh0 where a is the
+                // largest limb of the input. a = x0_val[m2], ..
+                auto x0 = var(var_pos.x0.column() + m2 - 0, var_pos.x0.row());
+                auto x1 = var(var_pos.x0.column() + m2 - 1, var_pos.x0.row());
+                auto x2 = var(var_pos.x0.column() + m2 - 2, var_pos.x0.row());    // invalid if m2 == 1
+                auto sinh0 = var(var_pos.sinh0.column() + 0, var_pos.sinh0.row());
+                auto sinh1 = var(var_pos.sinh0.column() + 1, var_pos.sinh0.row());
+                auto sinh2 = var(var_pos.sinh0.column() + 2, var_pos.sinh0.row());    // invalid if m2 == 1
+                {
+                    constraint_type constraint;
+                    constraint.table_id = sinh_a_table_id;
+                    constraint.lookup_input = {x0, sinh0};
+                    constraints.push_back(constraint);
+                }
+                {
+                    constraint_type constraint;
+                    constraint.table_id = cosh_a_table_id;
+                    constraint.lookup_input = {x0, var(splat(var_pos.cosh0))};
+                    constraints.push_back(constraint);
+                }
+                {
+                    constraint_type constraint;
+                    constraint.table_id = sinh_b_table_id;
+                    constraint.lookup_input = {x1, sinh1};
+                    constraints.push_back(constraint);
+                }
+                {
+                    constraint_type constraint;
+                    constraint.table_id = cosh_b_table_id;
+                    constraint.lookup_input = {x1, var(splat(var_pos.cosh1))};
+                    constraints.push_back(constraint);
+                }
+                if (m2 == 2) {
+                    constraint_type constraint;
+                    auto sinh_c_table_id =
+                        lookup_tables_indices.at(fixedpoint_hyperb_32_table<BlueprintFieldType>::FULL_SINH_C);
+                    constraint.table_id = sinh_c_table_id;
+                    constraint.lookup_input = {x2, sinh2};
+                    constraints.push_back(constraint);
+                }
+
+                return bp.add_lookup_gate(constraints);
+            }
+
+            template<typename BlueprintFieldType, typename ArithmetizationParams>
+            typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::result_type generate_circuit(
+                const plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams> &component,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                const typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::input_type
+                    &instance_input,
+                const std::size_t start_row_index) {
+                const auto var_pos = component.get_var_pos(static_cast<int64_t>(start_row_index));
+
+                std::size_t selector_index = generate_gates(component, bp, assignment, instance_input);
+
+                assignment.enable_selector(selector_index, start_row_index + component.rows_amount - 1);
+
+// Allows disabling lookup tables for faster testing
+#ifndef TEST_WITHOUT_LOOKUP_TABLES
+                std::size_t lookup_selector_index = generate_lookup_gates(component, bp, assignment, instance_input);
+                assignment.enable_selector(lookup_selector_index, start_row_index + component.rows_amount - 1);
+#endif
+                generate_copy_constraints(component, bp, assignment, instance_input, start_row_index);
+
+                return typename plonk_fixedpoint_sinh<BlueprintFieldType, ArithmetizationParams>::result_type(
+                    component, start_row_index);
+            }
+
+        }    // namespace components
+    }        // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_BLUEPRINT_PLONK_FIXEDPOINT_SINH_HPP

--- a/include/nil/blueprint/components/algebra/fixedpoint/tables.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/tables.hpp
@@ -24,6 +24,12 @@ namespace nil {
                 static std::vector<value_type> fill_sin_c_table(uint8_t m2);    // 2^16*-2
                 static std::vector<value_type> fill_cos_a_table(uint8_t m2);    // 2^16*0
                 static std::vector<value_type> fill_cos_b_table(uint8_t m2);    // 2^16*-1
+                
+                static std::vector<value_type> fill_sinh_a_table(uint8_t m2);    // 2^16*0
+                static std::vector<value_type> fill_sinh_b_table(uint8_t m2);    // 2^16*-1
+                static std::vector<value_type> fill_sinh_c_table(uint8_t m2);    // 2^16*-2
+                static std::vector<value_type> fill_cosh_a_table(uint8_t m2);    // 2^16*0
+                static std::vector<value_type> fill_cosh_b_table(uint8_t m2);    // 2^16*-1
 
             public:
                 FixedPointTables() = delete;
@@ -54,6 +60,16 @@ namespace nil {
                 static const std::vector<value_type> &get_sin_b_32();
                 static const std::vector<value_type> &get_cos_b_32();
                 static const std::vector<value_type> &get_sin_c_32();
+
+                static const std::vector<value_type> &get_sinh_a_16();
+                static const std::vector<value_type> &get_cosh_a_16();
+                static const std::vector<value_type> &get_sinh_a_32();
+                static const std::vector<value_type> &get_cosh_a_32();
+                static const std::vector<value_type> &get_sinh_b_16();
+                static const std::vector<value_type> &get_cosh_b_16();
+                static const std::vector<value_type> &get_sinh_b_32();
+                static const std::vector<value_type> &get_cosh_b_32();
+                static const std::vector<value_type> &get_sinh_c_32();
 
                 template<uint8_t M2>
                 static constexpr uint16_t get_exp_scale();
@@ -93,6 +109,20 @@ namespace nil {
 
             template<typename BlueprintFieldType>
             const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_sinh_a_16() {
+                static std::vector<value_type> sinh_a = fill_sinh_a_table(1);
+                return sinh_a;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_cosh_a_16() {
+                static std::vector<value_type> cosh_a = fill_cosh_a_table(1);
+                return cosh_a;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
                 FixedPointTables<BlueprintFieldType>::get_exp_a_32() {
                 static std::vector<value_type> exp_a = fill_exp_a_table(2);
                 return exp_a;
@@ -114,6 +144,20 @@ namespace nil {
 
             template<typename BlueprintFieldType>
             const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_sinh_a_32() {
+                static std::vector<value_type> sinh_a = fill_sinh_a_table(2);
+                return sinh_a;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_cosh_a_32() {
+                static std::vector<value_type> cosh_a = fill_cosh_a_table(2);
+                return cosh_a;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
                 FixedPointTables<BlueprintFieldType>::get_exp_b_16() {
                 static std::vector<value_type> exp_b = fill_exp_b_table(1);
                 return exp_b;
@@ -131,6 +175,20 @@ namespace nil {
                 FixedPointTables<BlueprintFieldType>::get_cos_b_16() {
                 static std::vector<value_type> cos_b = fill_cos_b_table(1);
                 return cos_b;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_sinh_b_16() {
+                static std::vector<value_type> sinh_b = fill_sinh_b_table(1);
+                return sinh_b;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_cosh_b_16() {
+                static std::vector<value_type> cosh_b = fill_cosh_b_table(1);
+                return cosh_b;
             }
 
             template<typename BlueprintFieldType>
@@ -159,6 +217,27 @@ namespace nil {
                 FixedPointTables<BlueprintFieldType>::get_sin_c_32() {
                 static std::vector<value_type> sin_c = fill_sin_c_table(2);
                 return sin_c;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_sinh_b_32() {
+                static std::vector<value_type> sinh_b = fill_sinh_b_table(2);
+                return sinh_b;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_cosh_b_32() {
+                static std::vector<value_type> cosh_b = fill_cosh_b_table(2);
+                return cosh_b;
+            }
+
+            template<typename BlueprintFieldType>
+            const std::vector<typename FixedPointTables<BlueprintFieldType>::value_type> &
+                FixedPointTables<BlueprintFieldType>::get_sinh_c_32() {
+                static std::vector<value_type> sinh_c = fill_sinh_c_table(2);
+                return sinh_c;
             }
 
             template<typename BlueprintFieldType>
@@ -256,6 +335,54 @@ namespace nil {
 
             template<typename BlueprintFieldType>
             std::vector<typename FixedPointTables<BlueprintFieldType>::value_type>
+                FixedPointTables<BlueprintFieldType>::fill_sinh_a_table(uint8_t m2) {
+                BLUEPRINT_RELEASE_ASSERT(m2 == 1 || m2 == 2);
+                std::vector<value_type> sinh_a;
+                sinh_a.reserve(SinXLen);
+                for (auto i = 0; i < SinXLen; ++i) {
+                    double val = std::sinh(static_cast<double>(i) / (1ULL << SinXScale * 0));
+                    val *= (1ULL << (16 * m2));
+                    auto int_val = int64_t(val);
+                    auto field_val = value_type(int_val);
+                    sinh_a.push_back(field_val);
+                }
+                return sinh_a;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename FixedPointTables<BlueprintFieldType>::value_type>
+                FixedPointTables<BlueprintFieldType>::fill_sinh_b_table(uint8_t m2) {
+                BLUEPRINT_RELEASE_ASSERT(m2 == 1 || m2 == 2);
+                std::vector<value_type> sinh_b;
+                sinh_b.reserve(SinXLen);
+                for (auto i = 0; i < SinXLen; ++i) {
+                    double val = std::sinh(static_cast<double>(i) / (1ULL << SinXScale * 1));
+                    val *= (1ULL << (16 * m2));
+                    auto int_val = uint64_t(val);
+                    auto field_val = value_type(int_val);
+                    sinh_b.push_back(field_val);
+                }
+                return sinh_b;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename FixedPointTables<BlueprintFieldType>::value_type>
+                FixedPointTables<BlueprintFieldType>::fill_sinh_c_table(uint8_t m2) {
+                BLUEPRINT_RELEASE_ASSERT(m2 == 2);
+                std::vector<value_type> sinh_c;
+                sinh_c.reserve(SinXLen);
+                for (auto i = 0; i < SinXLen; ++i) {
+                    double val = std::sinh(static_cast<double>(i) / (1ULL << SinXScale * 2));
+                    val *= (1ULL << (16 * m2));
+                    auto int_val = uint64_t(val);
+                    auto field_val = value_type(int_val);
+                    sinh_c.push_back(field_val);
+                }
+                return sinh_c;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename FixedPointTables<BlueprintFieldType>::value_type>
                 FixedPointTables<BlueprintFieldType>::fill_cos_a_table(uint8_t m2) {
                 BLUEPRINT_RELEASE_ASSERT(m2 == 1 || m2 == 2);
                 std::vector<value_type> cos_a;
@@ -284,6 +411,38 @@ namespace nil {
                     cos_b.push_back(field_val);
                 }
                 return cos_b;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename FixedPointTables<BlueprintFieldType>::value_type>
+                FixedPointTables<BlueprintFieldType>::fill_cosh_a_table(uint8_t m2) {
+                BLUEPRINT_RELEASE_ASSERT(m2 == 1 || m2 == 2);
+                std::vector<value_type> cosh_a;
+                cosh_a.reserve(CosXLen);
+                for (auto i = 0; i < CosXLen; ++i) {
+                    double val = std::cosh(static_cast<double>(i) / (1ULL << CosXScale * 0));
+                    val *= (1ULL << (16 * m2));
+                    auto int_val = int64_t(val);
+                    auto field_val = value_type(int_val);
+                    cosh_a.push_back(field_val);
+                }
+                return cosh_a;
+            }
+
+            template<typename BlueprintFieldType>
+            std::vector<typename FixedPointTables<BlueprintFieldType>::value_type>
+                FixedPointTables<BlueprintFieldType>::fill_cosh_b_table(uint8_t m2) {
+                BLUEPRINT_RELEASE_ASSERT(m2 == 1 || m2 == 2);
+                std::vector<value_type> cosh_b;
+                cosh_b.reserve(CosXLen);
+                for (auto i = 0; i < CosXLen; ++i) {
+                    double val = std::cosh(static_cast<double>(i) / (1ULL << CosXScale * 1));
+                    val *= (1ULL << (16 * m2));
+                    auto int_val = uint64_t(val);
+                    auto field_val = value_type(int_val);
+                    cosh_b.push_back(field_val);
+                }
+                return cosh_b;
             }
 
             template<typename BlueprintFieldType>

--- a/include/nil/blueprint/components/algebra/fixedpoint/type.hpp
+++ b/include/nil/blueprint/components/algebra/fixedpoint/type.hpp
@@ -19,6 +19,13 @@
 #define COS_COMPUTATION_2(sin0, sin1, sin2, cos0, cos1, cos2) \
     (cos2 * (cos0 * cos1 - sin0 * sin1) - sin2 * (sin0 * cos1 + cos0 * sin1))
 
+#define SINH_COMPUTATION_1(sinh0, sinh1, cosh0, cosh1, sign_val) sign_val *(sinh0 * cosh1 + cosh0 * sinh1)
+#define SINH_COMPUTATION_2(sinh0, sinh1, sinh2, cosh0, cosh1, cosh2, sign_val) \
+    sign_val *(cosh2 * (sinh0 * cosh1 + cosh0 * sinh1) + sinh2 * (cosh0 * cosh1 + sinh0 * sinh1))
+#define COSH_COMPUTATION_1(sinh0, sinh1, cosh0, cosh1) (cosh0 * cosh1 + sinh0 * sinh1)
+#define COSH_COMPUTATION_2(sinh0, sinh1, sinh2, cosh0, cosh1, cosh2) \
+    (cosh2 * (cosh0 * cosh1 + sinh0 * sinh1) + sinh2 * (sinh0 * cosh1 + cosh0 * sinh1))
+
 namespace nil {
     namespace blueprint {
         namespace components {
@@ -87,13 +94,12 @@ namespace nil {
                 value_type value;
                 uint16_t scale;
 
-                void trigonometric_helper(value_type &sin0,
-                                          value_type &sin1,
-                                          value_type &sin2,
-                                          value_type &cos0,
-                                          value_type &cos1,
-                                          value_type &cos2,
-                                          value_type &sign_val) const;
+                void trigonometric_helper(value_type &sin0, value_type &sin1, value_type &sin2, value_type &cos0,
+                                          value_type &cos1, value_type &cos2, value_type &sign_val) const;
+
+                void hyperbolic_helper(value_type &sinh0, value_type &sinh1, value_type &sinh2, value_type &cosh0,
+                                       value_type &cosh1, value_type &cosh2, value_type &sign_val, value_type &h,
+                                       value_type &max) const;
 
             public:
                 static constexpr uint8_t M_1 = M1;
@@ -141,6 +147,8 @@ namespace nil {
                 FixedPoint rescale() const;
                 static FixedPoint dot(const std::vector<FixedPoint> &, const std::vector<FixedPoint> &);
 
+                FixedPoint sinh() const;
+                FixedPoint cosh() const;
                 FixedPoint tanh() const;
 
                 double to_double() const;
@@ -751,6 +759,89 @@ namespace nil {
             }
 
             template<typename BlueprintFieldType, uint8_t M1, uint8_t M2>
+            void FixedPoint<BlueprintFieldType, M1, M2>::hyperbolic_helper(value_type &sinh0,
+                                                                           value_type &sinh1,
+                                                                           value_type &sinh2,
+                                                                           value_type &cosh0,
+                                                                           value_type &cosh1,
+                                                                           value_type &cosh2,
+                                                                           value_type &sign_val,
+                                                                           value_type &h,
+                                                                           value_type &max) const {
+                BLUEPRINT_RELEASE_ASSERT(scale == SCALE);
+
+                if constexpr (M1 == 1 && M2 == 1) {
+                    h = value_type(772243ULL);
+                    max = value_type(4294967295ULL);
+                } else if constexpr (M1 == 2 && M2 == 1) {
+                    h = value_type(1499061ULL);
+                    max = value_type(281474976710655ULL);
+                } else if constexpr (M1 == 1 && M2 == 2) {
+                    h = value_type(50609756021ULL);
+                    max = value_type(281474976710655ULL);
+                } else if constexpr (M1 == 2 && M2 == 2) {
+                    h = value_type(98242467570ULL);
+                    max = value_type(18446744073709551615ULL);
+                } else {
+                    BLUEPRINT_RELEASE_ASSERT(false);
+                }
+
+                using value_type = typename BlueprintFieldType::value_type;
+
+                auto zero = value_type::zero();
+                auto one = value_type::one();
+                auto delta = value_type(DELTA);
+
+                std::vector<value_type> sinh_a;
+                if constexpr (M2 == 1) {
+                    sinh_a = FixedPointTables<BlueprintFieldType>::get_sinh_a_16();
+                } else {
+                    sinh_a = FixedPointTables<BlueprintFieldType>::get_sinh_a_32();
+                }
+
+                std::vector<value_type> sinh_b;
+                if constexpr (M2 == 1) {
+                    sinh_b = FixedPointTables<BlueprintFieldType>::get_sinh_b_16();
+                } else {
+                    sinh_b = FixedPointTables<BlueprintFieldType>::get_sinh_b_32();
+                }
+
+                std::vector<value_type> sinh_c;
+                if constexpr (M2 == 2) {
+                    sinh_c = FixedPointTables<BlueprintFieldType>::get_sinh_c_32();
+                }
+
+                std::vector<value_type> cosh_a;
+                if constexpr (M2 == 1) {
+                    cosh_a = FixedPointTables<BlueprintFieldType>::get_cosh_a_16();
+                } else {
+                    cosh_a = FixedPointTables<BlueprintFieldType>::get_cosh_a_32();
+                }
+
+                std::vector<value_type> cosh_b;
+                if constexpr (M2 == 1) {
+                    cosh_b = FixedPointTables<BlueprintFieldType>::get_cosh_b_16();
+                } else {
+                    cosh_b = FixedPointTables<BlueprintFieldType>::get_cosh_b_32();
+                }
+
+                std::vector<uint16_t> x0_val;
+                bool sign = FixedPointHelper<BlueprintFieldType>::decompose(value, x0_val);
+                BLUEPRINT_RELEASE_ASSERT(x0_val.size() >= M2 + M1);
+                sign_val = sign ? -one : one;
+
+                sinh0 = sinh_a[x0_val[M2 - 0]];
+                sinh1 = sinh_b[x0_val[M2 - 1]];
+                sinh2 = zero;
+                if constexpr (M2 == 2) {
+                    sinh2 = sinh_c[x0_val[M2 - 2]];
+                }
+                cosh0 = cosh_a[x0_val[M2 - 0]];
+                cosh1 = cosh_b[x0_val[M2 - 1]];
+                cosh2 = delta;
+            }
+
+            template<typename BlueprintFieldType, uint8_t M1, uint8_t M2>
             FixedPoint<BlueprintFieldType, M1, M2> FixedPoint<BlueprintFieldType, M1, M2>::sin() const {
                 BLUEPRINT_RELEASE_ASSERT(scale == SCALE);
 
@@ -776,6 +867,38 @@ namespace nil {
             }
 
             template<typename BlueprintFieldType, uint8_t M1, uint8_t M2>
+            FixedPoint<BlueprintFieldType, M1, M2> FixedPoint<BlueprintFieldType, M1, M2>::sinh() const {
+                BLUEPRINT_RELEASE_ASSERT(scale == SCALE);
+
+                using value_type = typename BlueprintFieldType::value_type;
+                auto delta = value_type(DELTA);
+
+                value_type sinh0, sinh1, sinh2, cosh0, cosh1, cosh2, sign_val, h, max, x_abs, d;
+                hyperbolic_helper(sinh0, sinh1, sinh2, cosh0, cosh1, cosh2, sign_val, h, max);
+
+                x_abs = value;
+                FixedPointHelper<BlueprintFieldType>::abs(x_abs);
+                d = h - x_abs;
+                if (FixedPointHelper<BlueprintFieldType>::abs(d)) {
+                    return FixedPoint(sign_val * max, SCALE);
+                }
+
+                value_type actual_delta = delta;
+                if constexpr (M2 == 2) {
+                    actual_delta *= delta;
+                }
+
+                value_type computation;
+                if constexpr (M2 == 1) {
+                    computation = SINH_COMPUTATION_1(sinh0, sinh1, cosh0, cosh1, sign_val);
+                } else {
+                    computation = SINH_COMPUTATION_2(sinh0, sinh1, sinh2, cosh0, cosh1, cosh2, sign_val);
+                }
+                auto divmod = FixedPointHelper<BlueprintFieldType>::round_div_mod(computation, actual_delta);
+                return FixedPoint(divmod.quotient, SCALE);
+            }
+
+            template<typename BlueprintFieldType, uint8_t M1, uint8_t M2>
             FixedPoint<BlueprintFieldType, M1, M2> FixedPoint<BlueprintFieldType, M1, M2>::cos() const {
                 BLUEPRINT_RELEASE_ASSERT(scale == SCALE);
 
@@ -795,6 +918,38 @@ namespace nil {
                     computation = COS_COMPUTATION_1(sin0, sin1, cos0, cos1);
                 } else {
                     computation = COS_COMPUTATION_2(sin0, sin1, sin2, cos0, cos1, cos2);
+                }
+                auto divmod = FixedPointHelper<BlueprintFieldType>::round_div_mod(computation, actual_delta);
+                return FixedPoint(divmod.quotient, SCALE);
+            }
+
+            template<typename BlueprintFieldType, uint8_t M1, uint8_t M2>
+            FixedPoint<BlueprintFieldType, M1, M2> FixedPoint<BlueprintFieldType, M1, M2>::cosh() const {
+                BLUEPRINT_RELEASE_ASSERT(scale == SCALE);
+
+                using value_type = typename BlueprintFieldType::value_type;
+                auto delta = value_type(DELTA);
+
+                value_type sinh0, sinh1, sinh2, cosh0, cosh1, cosh2, sign_val, h, max, x_abs, d;
+                hyperbolic_helper(sinh0, sinh1, sinh2, cosh0, cosh1, cosh2, sign_val, h, max);
+
+                x_abs = value;
+                FixedPointHelper<BlueprintFieldType>::abs(x_abs);
+                d = h - x_abs;
+                if (FixedPointHelper<BlueprintFieldType>::abs(d)) {
+                    return FixedPoint(max, SCALE);
+                }
+
+                value_type actual_delta = delta;
+                if constexpr (M2 == 2) {
+                    actual_delta *= delta;
+                }
+
+                value_type computation;
+                if constexpr (M2 == 1) {
+                    computation = COSH_COMPUTATION_1(sinh0, sinh1, cosh0, cosh1);
+                } else {
+                    computation = COSH_COMPUTATION_2(sinh0, sinh1, sinh2, cosh0, cosh1, cosh2);
                 }
                 auto divmod = FixedPointHelper<BlueprintFieldType>::round_div_mod(computation, actual_delta);
                 return FixedPoint(divmod.quotient, SCALE);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -205,6 +205,7 @@ SET(FIXEDPOINT_TESTS_FILES
     "algebra/fixedpoint/plonk/advanced_operations"
     "algebra/fixedpoint/plonk/tester"
     "algebra/fixedpoint/plonk/trigonometric"
+    "algebra/fixedpoint/plonk/hyperbolic"
     "algebra/fixedpoint/plonk/erf"
     "algebra/fixedpoint/plonk/boolean"
     "algebra/fields/plonk/bitwise"

--- a/test/algebra/fixedpoint/plonk/hyperbolic.cpp
+++ b/test/algebra/fixedpoint/plonk/hyperbolic.cpp
@@ -1,0 +1,311 @@
+#define BOOST_TEST_MODULE blueprint_plonk_fixedpoint_hyperbolic_operations_test
+
+// Enable for faster tests
+// #define TEST_WITHOUT_LOOKUP_TABLES
+
+#include <boost/test/unit_test.hpp>
+
+#include <nil/crypto3/algebra/fields/bls12/scalar_field.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/bls12.hpp>
+#include <nil/crypto3/algebra/curves/vesta.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/vesta.hpp>
+#include <nil/crypto3/algebra/curves/pallas.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/pallas.hpp>
+
+#include <nil/crypto3/hash/keccak.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <boost/random/mersenne_twister.hpp>
+
+#include <nil/blueprint/blueprint/plonk/assignment.hpp>
+#include <nil/blueprint/blueprint/plonk/circuit.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/type.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/plonk/sinh.hpp>
+#include <nil/blueprint/components/algebra/fixedpoint/plonk/cosh.hpp>
+
+#include "../../../test_plonk_component.hpp"
+
+using namespace nil;
+using nil::blueprint::components::FixedPoint16_16;
+using nil::blueprint::components::FixedPoint16_32;
+using nil::blueprint::components::FixedPoint32_16;
+using nil::blueprint::components::FixedPoint32_32;
+
+static constexpr double EPSILON = 0.01;
+
+#define PRINT_FIXED_POINT_TEST(what)                                                                                \
+    std::cout << "fixed_point " << what << " test:\n";                                                              \
+    std::cout << "input           : " << input.get_value().data << "\n";                                            \
+    std::cout << "input (float)   : " << input.to_double() << "\n";                                                 \
+    std::cout << "expected        : " << expected_res.get_value().data << "\n";                                     \
+    std::cout << "real            : " << real_res_.get_value().data << "\n";                                        \
+    std::cout << "expected (float): " << expected_res_f << "\n";                                                    \
+    std::cout << "real (float)    : " << real_res_f << "\n";                                                        \
+    std::cout << "modulus    : " << BlueprintFieldType::modulus << "\n";                                            \
+    std::cout << "having " << static_cast<int>(16 * FixedType::M_1) << "." << static_cast<int>(16 * FixedType::M_2) \
+              << std::endl;
+
+bool doubleEquals(double a, double b, double epsilon, uint8_t m1, uint8_t m2) {
+    // Essentially equal from
+    // https://stackoverflow.com/questions/17333/how-do-you-compare-float-and-double-while-accounting-for-precision-loss
+    // or just smaller epsilon
+    double upper = 0.;
+    if (2 == (m1 + m2)) {
+        upper = static_cast<double>(4294967295ULL) / static_cast<double>(1ULL << (16 * m2));    // 2^32 - 1
+    } else if (3 == (m1 + m2)) {
+        upper = static_cast<double>(281474976710655ULL) / static_cast<double>(1ULL << (16 * m2));    // 2^48 - 1
+    } else if (4 == (m1 + m2)) {
+        upper = static_cast<double>(18446744073709551615ULL) / static_cast<double>(1ULL << (16 * m2));    // 2^64 - 1
+    }
+    if (fabs(a) >= upper) {
+        return true;
+    }
+    return fabs(a - b) < epsilon || fabs(a - b) <= ((fabs(a) > fabs(b) ? fabs(b) : fabs(a)) * epsilon);
+}
+
+template<typename FixedType>
+void test_fixedpoint_sinh(FixedType input) {
+    using BlueprintFieldType = typename FixedType::field_type;
+    constexpr std::size_t WitnessColumns =
+        FixedType::M_2 == 1 ? 9 + 2 * (FixedType::M_1 + FixedType::M_2) : 7 + FixedType::M_1 + FixedType::M_2;
+    constexpr std::size_t PublicInputColumns = 1;
+#ifdef TEST_WITHOUT_LOOKUP_TABLES
+    constexpr std::size_t ConstantColumns = 0;
+    constexpr std::size_t SelectorColumns = 1;
+#else
+    constexpr std::size_t ConstantColumns = 8;
+    constexpr std::size_t SelectorColumns = 8;
+#endif
+    using ArithmetizationParams = crypto3::zk::snark::
+        plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
+    using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
+    using hash_type = nil::crypto3::hashes::keccak_1600<256>;
+    constexpr std::size_t Lambda = 40;
+    using AssignmentType = nil::blueprint::assignment<ArithmetizationType>;
+
+    using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
+
+    using component_type = blueprint::components::
+        fix_sinh<ArithmetizationType, BlueprintFieldType, nil::blueprint::basic_non_native_policy<BlueprintFieldType>>;
+
+    typename component_type::input_type instance_input = {var(0, 0, false, var::column_type::public_input)};
+
+    double expected_res_f = sinh(input.to_double());
+    auto expected_res = input.sinh();
+
+    auto result_check = [&expected_res, &expected_res_f, input](AssignmentType &assignment,
+                                                                typename component_type::result_type &real_res) {
+        auto real_res_ = FixedType(var_value(assignment, real_res.output), FixedType::SCALE);
+        double real_res_f = real_res_.to_double();
+#ifdef BLUEPRINT_PLONK_PROFILING_ENABLED
+        PRINT_FIXED_POINT_TEST("sinh")
+#endif
+        if (!doubleEquals(expected_res_f, real_res_f, EPSILON, FixedType::M_1, FixedType::M_2) ||
+            expected_res != real_res_) {
+            PRINT_FIXED_POINT_TEST("sinh")
+            abort();
+        }
+    };
+
+    std::vector<std::uint32_t> witness_list;
+    witness_list.reserve(WitnessColumns);
+    for (auto i = 0; i < WitnessColumns; i++) {
+        witness_list.push_back(i);
+    }
+    std::vector<std::uint32_t> const_list;
+    const_list.reserve(ConstantColumns);
+    for (auto i = 0; i < ConstantColumns; i++) {
+        const_list.push_back(i);
+    }
+    // Is done by the manifest in a real circuit
+    component_type component_instance(
+        witness_list, const_list, std::array<std::uint32_t, 0>(), FixedType::M_1, FixedType::M_2);
+
+    std::vector<typename BlueprintFieldType::value_type> public_input = {input.get_value()};
+    nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
+        component_instance,
+        public_input,
+        result_check,
+        instance_input,
+        crypto3::detail::connectedness_check_type::STRONG,
+        FixedType::M_1,
+        FixedType::M_2);
+}
+
+template<typename FixedType>
+void test_fixedpoint_cosh(FixedType input) {
+    using BlueprintFieldType = typename FixedType::field_type;
+    constexpr std::size_t WitnessColumns =
+        FixedType::M_2 == 1 ? 9 + 2 * (FixedType::M_1 + FixedType::M_2) : 7 + FixedType::M_1 + FixedType::M_2;
+    constexpr std::size_t PublicInputColumns = 1;
+#ifdef TEST_WITHOUT_LOOKUP_TABLES
+    constexpr std::size_t ConstantColumns = 0;
+    constexpr std::size_t SelectorColumns = 1;
+#else
+    constexpr std::size_t ConstantColumns = 8;
+    constexpr std::size_t SelectorColumns = 8;
+#endif
+    using ArithmetizationParams = crypto3::zk::snark::
+        plonk_arithmetization_params<WitnessColumns, PublicInputColumns, ConstantColumns, SelectorColumns>;
+    using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
+    using hash_type = nil::crypto3::hashes::keccak_1600<256>;
+    constexpr std::size_t Lambda = 40;
+    using AssignmentType = nil::blueprint::assignment<ArithmetizationType>;
+
+    using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
+
+    using component_type = blueprint::components::
+        fix_cosh<ArithmetizationType, BlueprintFieldType, nil::blueprint::basic_non_native_policy<BlueprintFieldType>>;
+
+    typename component_type::input_type instance_input = {var(0, 0, false, var::column_type::public_input)};
+
+    double expected_res_f = cosh(input.to_double());
+    auto expected_res = input.cosh();
+
+    auto result_check = [&expected_res, &expected_res_f, input](AssignmentType &assignment,
+                                                                typename component_type::result_type &real_res) {
+        auto real_res_ = FixedType(var_value(assignment, real_res.output), FixedType::SCALE);
+        double real_res_f = real_res_.to_double();
+#ifdef BLUEPRINT_PLONK_PROFILING_ENABLED
+        PRINT_FIXED_POINT_TEST("cosh")
+#endif
+        if (!doubleEquals(expected_res_f, real_res_f, EPSILON, FixedType::M_1, FixedType::M_2) ||
+            expected_res != real_res_) {
+            PRINT_FIXED_POINT_TEST("cosh")
+            abort();
+        }
+    };
+
+    std::vector<std::uint32_t> witness_list;
+    witness_list.reserve(WitnessColumns);
+    for (auto i = 0; i < WitnessColumns; i++) {
+        witness_list.push_back(i);
+    }
+    std::vector<std::uint32_t> const_list;
+    const_list.reserve(ConstantColumns);
+    for (auto i = 0; i < ConstantColumns; i++) {
+        const_list.push_back(i);
+    }
+    // Is done by the manifest in a real circuit
+    component_type component_instance(
+        witness_list, const_list, std::array<std::uint32_t, 0>(), FixedType::M_1, FixedType::M_2);
+
+    std::vector<typename BlueprintFieldType::value_type> public_input = {input.get_value()};
+    nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
+        component_instance,
+        public_input,
+        result_check,
+        instance_input,
+        crypto3::detail::connectedness_check_type::STRONG,
+        FixedType::M_1,
+        FixedType::M_2);
+}
+
+template<typename FieldType, typename RngType>
+FieldType generate_small_random_for_fixedpoint(uint8_t m1, uint8_t m2, RngType &rng) {
+    using distribution = boost::random::uniform_int_distribution<uint64_t>;
+
+    BLUEPRINT_RELEASE_ASSERT(m1 > 0 && m1 < 3);
+    BLUEPRINT_RELEASE_ASSERT(m2 > 0 && m2 < 3);
+
+    distribution dist = distribution(0, 23ULL << (16 * m2));
+    uint64_t x = dist(rng);
+    distribution dist_bool = distribution(0, 1);
+    bool sign = dist_bool(rng) == 1;
+    if (sign) {
+        return -FieldType(x);
+    } else {
+        return FieldType(x);
+    }
+}
+
+template<typename FieldType, typename RngType>
+FieldType generate_random_for_fixedpoint(uint8_t m1, uint8_t m2, RngType &rng) {
+    using distribution = boost::random::uniform_int_distribution<uint64_t>;
+
+    BLUEPRINT_RELEASE_ASSERT(m1 > 0 && m1 < 3);
+    BLUEPRINT_RELEASE_ASSERT(m2 > 0 && m2 < 3);
+
+    uint64_t upper = 0;
+    auto m = m1 + m2;
+    if (2 == m) {
+        upper = 4294967295ULL;    // 2^32 - 1
+    } else if (3 == m) {
+        upper = 281474976710655ULL;    // 2^48 - 1
+    } else if (4 == m) {
+        upper = 18446744073709551615ULL;    // 2^64 - 1
+    }
+
+    distribution dist = distribution(0, upper);
+    uint64_t x = dist(rng);
+    distribution dist_bool = distribution(0, 1);
+    bool sign = dist_bool(rng) == 1;
+    if (sign) {
+        return -FieldType(x);
+    } else {
+        return FieldType(x);
+    }
+}
+
+template<typename FixedType, typename RngType>
+void test_components_on_random_data(RngType &rng) {
+    FixedType x(generate_random_for_fixedpoint<typename FixedType::value_type>(FixedType::M_1, FixedType::M_2, rng),
+                FixedType::SCALE);
+    test_fixedpoint_sinh<FixedType>(x);
+    test_fixedpoint_cosh<FixedType>(x);
+    FixedType y(
+        generate_small_random_for_fixedpoint<typename FixedType::value_type>(FixedType::M_1, FixedType::M_2, rng),
+        FixedType::SCALE);
+    test_fixedpoint_sinh<FixedType>(y);
+    test_fixedpoint_cosh<FixedType>(y);
+}
+
+template<typename FixedType>
+void test_components(double i) {
+    FixedType x(i);
+    test_fixedpoint_sinh<FixedType>(x);
+    test_fixedpoint_cosh<FixedType>(x);
+}
+
+template<typename FixedType, std::size_t RandomTestsAmount>
+void field_operations_test() {
+
+    for (int i = -23; i < 24; i++) {
+        test_components<FixedType>(i);
+        test_components<FixedType>(i);
+    }
+
+    boost::random::mt19937 seed_seq(0);
+    for (std::size_t i = 0; i < RandomTestsAmount; i++) {
+        test_components_on_random_data<FixedType>(seed_seq);
+    }
+}
+
+constexpr static const std::size_t random_tests_amount = 10;
+
+BOOST_AUTO_TEST_SUITE(blueprint_plonk_test_suite)
+
+BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_hyperbolic_test_vesta) {
+    using field_type = typename crypto3::algebra::curves::vesta::base_field_type;
+    field_operations_test<FixedPoint16_16<field_type>, random_tests_amount>();
+    field_operations_test<FixedPoint32_16<field_type>, random_tests_amount>();
+    field_operations_test<FixedPoint16_32<field_type>, random_tests_amount>();
+    field_operations_test<FixedPoint32_32<field_type>, random_tests_amount>();
+}
+
+BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_hyperbolic_test_pallas) {
+    using field_type = typename crypto3::algebra::curves::pallas::base_field_type;
+    field_operations_test<FixedPoint16_16<field_type>, random_tests_amount>();
+    field_operations_test<FixedPoint32_16<field_type>, random_tests_amount>();
+    field_operations_test<FixedPoint16_32<field_type>, random_tests_amount>();
+    field_operations_test<FixedPoint32_32<field_type>, random_tests_amount>();
+}
+
+BOOST_AUTO_TEST_CASE(blueprint_plonk_fixedpoint_hyperbolic_test_bls12) {
+    using field_type = typename crypto3::algebra::fields::bls12_fr<381>;
+    field_operations_test<FixedPoint16_16<field_type>, random_tests_amount>();
+    field_operations_test<FixedPoint32_16<field_type>, random_tests_amount>();
+    field_operations_test<FixedPoint16_32<field_type>, random_tests_amount>();
+    field_operations_test<FixedPoint32_32<field_type>, random_tests_amount>();
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The structure of the sinh and cosh gadgets was taken from the sin and cos gadgets. Evaluations with large absolute values of sinh and cosh get clipped to the max/min value of the current fixed point representation.